### PR TITLE
fix: self-update in parallel processes does not work properly

### DIFF
--- a/pkg/util/delay_file.go
+++ b/pkg/util/delay_file.go
@@ -1,0 +1,84 @@
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/werf/lockgate"
+)
+
+type DelayFile struct {
+	Locker   lockgate.Locker
+	FilePath string
+	Delay    time.Duration
+}
+
+func NewDelayFile(locker lockgate.Locker, filePath string, delay time.Duration) DelayFile {
+	return DelayFile{
+		Locker:   locker,
+		FilePath: filePath,
+		Delay:    delay,
+	}
+}
+
+func (u DelayFile) IsDelayPassed() (passed bool, err error) {
+	err = lockgate.WithAcquire(u.Locker, u.FilePath, lockgate.AcquireOptions{Shared: true, Timeout: 30 * time.Second}, func(_ bool) error {
+		passed, err = u.isDelayPassed()
+		return err
+	})
+
+	return
+}
+
+func (u DelayFile) isDelayPassed() (bool, error) {
+	info, err := os.Stat(u.FilePath)
+	if err != nil {
+		if isNotExistErr(err) {
+			return true, nil
+		}
+
+		return false, nil
+	}
+
+	fTime := info.ModTime()
+	if fTime.Add(u.Delay).Before(time.Now()) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (u DelayFile) UpdateTimestamp() error {
+	return lockgate.WithAcquire(u.Locker, u.FilePath, lockgate.AcquireOptions{Shared: false, Timeout: 30 * time.Second}, func(_ bool) error {
+		return u.updateTimestamp()
+	})
+}
+
+func (u DelayFile) updateTimestamp() error {
+	exist, err := IsRegularFileExist(u.FilePath)
+	if err != nil {
+		return err
+	}
+
+	if exist {
+		if err := os.Remove(u.FilePath); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(u.FilePath), os.ModePerm); err != nil {
+		return err
+	}
+
+	f, err := os.Create(u.FilePath)
+	if err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add 30 seconds delay between updates due to there is no proper way to prevent the following possible errors during parallel updates:
```
# unix: attempt to update current program path that points to non-existent file after the parallel self-update
Error: rename /home/user/go/bin/.trdl.old /home/user/go/bin/..trdl.old.old: no such file or directory

# windows: attempt to replace real current binary file (.trdl.exe.old) with the result binary file (trdl.exe) from the parallel self-update
Error: rename C:\Users\user\go\bin\trdl.exe C:\Users\user\go\bin\.trdl.exe.old: Access is denied.
```