### PR TITLE
fix(pgp-signing-key): fix error in the periodic task when pgp key not generated

### DIFF
--- a/server/path_publish.go
+++ b/server/path_publish.go
@@ -99,7 +99,8 @@ func (b *Backend) pathPublish(ctx context.Context, req *logical.Request, fields 
 	}
 
 	opts := cfg.RepositoryOptions()
-	opts.InitializeKeys = true
+	opts.InitializeTUFKeys = true
+	opts.InitializePGPSigningKey = true
 	publisherRepository, err := b.Publisher.GetRepository(ctx, req.Storage, opts)
 	if err != nil {
 		return nil, fmt.Errorf("error getting publisher repository: %s", err)

--- a/server/path_release.go
+++ b/server/path_release.go
@@ -112,7 +112,8 @@ func (b *Backend) pathRelease(ctx context.Context, req *logical.Request, fields 
 	}
 
 	opts := cfg.RepositoryOptions()
-	opts.InitializeKeys = true
+	opts.InitializeTUFKeys = true
+	opts.InitializePGPSigningKey = true
 	publisherRepository, err := b.Publisher.GetRepository(ctx, req.Storage, opts)
 	if err != nil {
 		return nil, fmt.Errorf("error getting publisher repository: %s", err)

--- a/server/periodic.go
+++ b/server/periodic.go
@@ -60,7 +60,8 @@ func (b *Backend) Periodic(ctx context.Context, req *logical.Request) error {
 	}
 
 	opts := config.RepositoryOptions()
-	opts.InitializeKeys = false
+	opts.InitializeTUFKeys = false
+	opts.InitializePGPSigningKey = true
 	publisherRepository, err := b.Publisher.GetRepository(ctx, req.Storage, opts)
 	if err == publisher.ErrUninitializedRepositoryKeys {
 		b.Logger().Info("Repository is not initialized: skipping periodic task")

--- a/server/pkg/publisher/backend.go
+++ b/server/pkg/publisher/backend.go
@@ -29,10 +29,7 @@ func (publisher *Publisher) Paths() []*framework.Path {
 }
 
 func (publisher *Publisher) pathConfigurePGPSigningKeyRead(ctx context.Context, req *logical.Request, fields *framework.FieldData) (*logical.Response, error) {
-	key, err := publisher.fetchPGPSigningKey(ctx, req.Storage, false)
-	if err == ErrUninitializedPGPSigningKey {
-		return logical.ErrorResponse(ErrUninitializedPGPSigningKey.Error()), nil
-	}
+	key, err := publisher.fetchPGPSigningKey(ctx, req.Storage, true)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching pgp signing key: %s", err)
 	}

--- a/server/pkg/publisher/publisher.go
+++ b/server/pkg/publisher/publisher.go
@@ -40,7 +40,8 @@ type RepositoryOptions struct {
 	S3SecretAccessKey string
 	S3BucketName      string
 
-	InitializeKeys bool
+	InitializeTUFKeys       bool
+	InitializePGPSigningKey bool
 }
 
 type InMemoryFile struct {
@@ -211,13 +212,13 @@ func (publisher *Publisher) GetRepository(ctx context.Context, storage logical.S
 		return nil, fmt.Errorf("error initializing repository: %s", err)
 	}
 
-	if err := publisher.setRepositoryKeys(ctx, storage, repository, setRepositoryKeysOptions{InitializeKeys: options.InitializeKeys}); err == ErrUninitializedRepositoryKeys {
+	if err := publisher.setRepositoryKeys(ctx, storage, repository, setRepositoryKeysOptions{InitializeKeys: options.InitializeTUFKeys}); err == ErrUninitializedRepositoryKeys {
 		return nil, ErrUninitializedRepositoryKeys
 	} else if err != nil {
 		return nil, fmt.Errorf("error initializing repository keys: %s", err)
 	}
 
-	pgpSigningKey, err := publisher.fetchPGPSigningKey(ctx, storage, options.InitializeKeys)
+	pgpSigningKey, err := publisher.fetchPGPSigningKey(ctx, storage, options.InitializePGPSigningKey)
 	if err != nil {
 		return nil, fmt.Errorf("error fetching pgp signing key: %s", err)
 	}


### PR DESCRIPTION
1. Do generate pgp signing key in the periodic task if not initialized yet.
2. Do generate pgp signing key in the configuration/pgp_signing_key getter.
3. Do generate pgp signing key in the release and publish tasks.