### PR TITLE
fix(client): unknown flag --home-dir

### DIFF
--- a/client/cmd/trdl/main.go
+++ b/client/cmd/trdl/main.go
@@ -73,5 +73,5 @@ func SetupHomeDir(cmd *cobra.Command) {
 		defaultHomeDir = "~/.trdl"
 	}
 
-	cmd.Flags().StringVarP(&homeDir, "home-dir", "", defaultHomeDir, "Set trdl home directory (default $TRDL_HOME_DIR or ~/.trdl)")
+	cmd.PersistentFlags().StringVarP(&homeDir, "home-dir", "", defaultHomeDir, "Set trdl home directory (default $TRDL_HOME_DIR or ~/.trdl)")
 }


### PR DESCRIPTION
`--home-dir` global flag parsing was disabled.

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>