### PR TITLE
ci(website_broken_links_checker): ignore http response code 0

### DIFF
--- a/.github/workflows/website_broken_links_checker.yml
+++ b/.github/workflows/website_broken_links_checker.yml
@@ -43,4 +43,5 @@ jobs:
             --empty-alt-ignore \
             --check_html \
             --url_ignore "https://fonts.googleapis.com,https://fonts.gstatic.com" \
+            --http-status-ignore "0" \
             _site/


### PR DESCRIPTION
External link https://www.vaultproject.io/docs/commands/plugin/register failed: got a time out (response code 0)

Signed-off-by: Alexey Igrychev <alexey.igrychev@flant.com>