### PR TITLE
fix(client): autoclean ignores releases downloaded by previous trdl versions

### DIFF
--- a/client/pkg/util/metafile.go
+++ b/client/pkg/util/metafile.go
@@ -30,10 +30,6 @@ func (f Metafile) HasBeenModifiedWithinPeriod(locker lockgate.Locker, period tim
 func (f Metafile) hasBeenModifiedWithinPeriod(period time.Duration) (bool, error) {
 	info, err := os.Stat(f.filePath)
 	if err != nil {
-		if isNotExistErr(err) {
-			return true, nil
-		}
-
 		return false, nil
 	}
 


### PR DESCRIPTION
Fix missing release metafile treated as recently modified.

Signed-off-by: Alexey Igrychev <alexey.igrychev@flant.com>