### PR TITLE
fix(signatures): fix signatures ignored when too many git notes exists for a repo

### DIFF
--- a/server/pkg/git/signatures_loader_test.go
+++ b/server/pkg/git/signatures_loader_test.go
@@ -1,0 +1,27 @@
+package git
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TODO: refactor this test
+var _ = XDescribe("Signatures loader from git NOTES", func() {
+	It("successfully loads werf signatures", func() {
+		tagName := "v1.2.84+fix1"
+
+		repo, err := CloneInMemory("https://github.com/werf/werf.git", CloneOptions{TagName: tagName})
+		Expect(err).To(Succeed())
+
+		tref, err := repo.Tag(tagName)
+		Expect(err).To(Succeed())
+
+		tobj, err := repo.TagObject(tref.Hash())
+		Expect(err).To(Succeed())
+
+		sigs, err := objectSignaturesFromNotes(repo, tobj.Hash.String())
+		Expect(err).To(Succeed())
+
+		Expect(len(sigs) > 0).To(BeTrue())
+	})
+})

--- a/server/pkg/git/utils.go
+++ b/server/pkg/git/utils.go
@@ -1,0 +1,16 @@
+package git
+
+import "path/filepath"
+
+func objectFanoutPaths(objectID string) (res []string) {
+	res = append(res, objectID)
+	if len(objectID) <= 2 {
+		return
+	}
+
+	for _, path := range objectFanoutPaths(objectID[2:]) {
+		res = append(res, filepath.Join(objectID[0:2], path))
+	}
+
+	return
+}

--- a/server/pkg/git/utils_test.go
+++ b/server/pkg/git/utils_test.go
@@ -1,0 +1,36 @@
+package git
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Utils", func() {
+	It("objectFanoutPaths", func() {
+		path := "44344dae578b8c9f53617f9dffec40b3f2ad91ae"
+		expectedRes := []string{
+			"44344dae578b8c9f53617f9dffec40b3f2ad91ae",
+			"44/344dae578b8c9f53617f9dffec40b3f2ad91ae",
+			"44/34/4dae578b8c9f53617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae578b8c9f53617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/578b8c9f53617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b8c9f53617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c9f53617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f53617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/617f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9dffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ffec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ff/ec40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ff/ec/40b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ff/ec/40/b3f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ff/ec/40/b3/f2ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ff/ec/40/b3/f2/ad91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ff/ec/40/b3/f2/ad/91ae",
+			"44/34/4d/ae/57/8b/8c/9f/53/61/7f/9d/ff/ec/40/b3/f2/ad/91/ae",
+		}
+
+		Expect(objectFanoutPaths(path)).To(Equal(expectedRes))
+	})
+})


### PR DESCRIPTION
Changed git-notes reading algorithm to take into account git notes files fanout naming.

Signed-off-by: Timofey Kirillov <timofey.kirillov@flant.com>