### PR TITLE
fix(server): fix artifact export and build commands leak

### DIFF
--- a/e2e/tests/flow/_fixtures/complete_cycle/trdl.yaml
+++ b/e2e/tests/flow/_fixtures/complete_cycle/trdl.yaml
@@ -1,6 +1,7 @@
 dockerImage: alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
 commands:
-  - '[ "$(cat /run/secrets/secretId0)" = "secretData" ] || (echo "Env does not match the expected value" && exit 1)'
+  - '[ "$(cat /run/secrets/secretId0-test)" = "secretData" ] || (echo "output does not match the expected value" && exit 1)'
+  - '[ "$(cat /run/secrets/secretId1-test)" = "secretData" ] || (echo "output does not match the expected value" && exit 1)'
   - mkdir -p /result/any-any/bin
   - printf "echo {{ .Tag }}\n" > /result/any-any/bin/script.sh
   - mkdir -p /result/windows-any/bin

--- a/e2e/tests/flow/complete_cycle_test.go
+++ b/e2e/tests/flow/complete_cycle_test.go
@@ -225,7 +225,7 @@ var _ = Describe("Complete cycle", func() {
 			req.Path = "configure/build/secrets"
 			req.Operation = logical.CreateOperation
 			req.Data = map[string]interface{}{
-				"id":   fmt.Sprintf("secretId%d", i),
+				"id":   fmt.Sprintf("secretId%d-test", i),
 				"data": "secretData",
 			}
 			_, err = backend.HandleRequest(context.Background(), req)


### PR DESCRIPTION
This solves several problems caused by moving to buildx:

- Error handling: buildx writes all the logs to stderr, so a custom parser was implemented to extract and return meaningful errors.
- Long execution times due to large Docker image sizes: Moved to a multi-stage build that exports only the artifacts to the tar writer.
- Command leakage: If the task context is canceled, the command still runs in the system. Added context to the command, ensuring it terminates the process when the context is canceled.