### PR TITLE
feat(client): add support for pinning explicit versions in main commands

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,12 +80,6 @@ jobs:
       - name: Test
         run: task --yes client:test:unit
 
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: unit_client_coverage
-          path: tests_coverage
-
   e2e_tests:
     name: End-to-end tests
     runs-on: ubuntu-22.04
@@ -141,7 +135,6 @@ jobs:
     name: Upload coverage
     needs:
       - unit_server
-      - unit_client
       - e2e_tests
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,32 @@ jobs:
           name: unit_coverage
           path: tests_coverage
 
+  unit_client:
+    name: Client unit tests
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: client/go.mod
+
+      - name: Install Task
+        uses: go-task/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Test
+        run: task --yes client:test:unit
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit_client_coverage
+          path: tests_coverage
+
   e2e_tests:
     name: End-to-end tests
     runs-on: ubuntu-22.04
@@ -115,6 +141,7 @@ jobs:
     name: Upload coverage
     needs:
       - unit_server
+      - unit_client
       - e2e_tests
     runs-on: ubuntu-22.04
     steps:
@@ -136,6 +163,7 @@ jobs:
     if: always()
     needs:
       - unit_server
+      - unit_client
       - e2e_tests
       - upload_coverage
     uses: werf/common-ci/.github/workflows/notification.yml@main

--- a/client/Taskfile.yaml
+++ b/client/Taskfile.yaml
@@ -164,11 +164,7 @@ tasks:
 
   test:unit:
     desc: "Run client unit tests."
-    cmds:
-      - mkdir -p {{.outputDir}}
-      - go test -tags test_coverage -gcflags=all=-l -cover -coverpkg=./... -coverprofile={{.outputDir}}/client-unit.out ./...
-    vars:
-      outputDir: '{{.outputDir | default "../tests_coverage/unit-client"}}'
+    cmd: go test ./...
 
   verify:dist:binaries:
     desc: "Verify that the distributable binaries are built and have correct platform/arch."

--- a/client/Taskfile.yaml
+++ b/client/Taskfile.yaml
@@ -162,6 +162,14 @@ tasks:
       outputBin: ../bin/coverage/trdl
       extraGoBuildArgs: '-ldflags="-s -w" -tags "test_coverage" -cover -covermode=atomic -coverpkg=./... -c cmd/trdl/*.go'
 
+  test:unit:
+    desc: "Run client unit tests."
+    cmds:
+      - mkdir -p {{.outputDir}}
+      - go test -tags test_coverage -gcflags=all=-l -cover -coverpkg=./... -coverprofile={{.outputDir}}/client-unit.out ./...
+    vars:
+      outputDir: '{{.outputDir | default "../tests_coverage/unit-client"}}'
+
   verify:dist:binaries:
     desc: "Verify that the distributable binaries are built and have correct platform/arch."
     cmds:

--- a/client/cmd/trdl/bin_path.go
+++ b/client/cmd/trdl/bin_path.go
@@ -11,22 +11,39 @@ import (
 
 func binPathCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "bin-path REPO GROUP [CHANNEL]",
+		Use:                   "bin-path REPO GROUP [CHANNEL] | REPO VERSION",
 		Short:                 "Get the directory with software binaries",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.RangeArgs(2, 3)(cmd, args); err != nil {
+			if err := validateVersionArgs(cmd, args); err != nil {
 				PrintHelp(cmd)
 				return err
 			}
 
 			repoName := args[0]
-			group := args[1]
 
 			if repoName == trdl.SelfUpdateDefaultRepo {
 				PrintHelp(cmd)
 				return fmt.Errorf("reserved repository name %q cannot be used", trdl.SelfUpdateDefaultRepo)
 			}
+
+			c, err := trdlClient.NewClient(homeDir)
+			if err != nil {
+				return fmt.Errorf("unable to initialize trdl client: %w", err)
+			}
+
+			if isVersionArg(args[1]) {
+				dir, err := c.GetRepoReleaseBinDir(repoName, parseVersionArg(args[1]))
+				if err != nil {
+					return err
+				}
+
+				fmt.Println(dir)
+
+				return nil
+			}
+
+			group := args[1]
 
 			var optionalChannel string
 			if len(args) == 3 {
@@ -35,11 +52,6 @@ func binPathCmd() *cobra.Command {
 					PrintHelp(cmd)
 					return err
 				}
-			}
-
-			c, err := trdlClient.NewClient(homeDir)
-			if err != nil {
-				return fmt.Errorf("unable to initialize trdl client: %w", err)
 			}
 
 			dir, err := c.GetRepoChannelReleaseBinDir(repoName, group, optionalChannel)

--- a/client/cmd/trdl/bin_path.go
+++ b/client/cmd/trdl/bin_path.go
@@ -33,7 +33,7 @@ func binPathCmd() *cobra.Command {
 			}
 
 			if isVersionArg(args[1]) {
-				dir, err := c.GetRepoReleaseBinDir(repoName, parseVersionArg(args[1]))
+				dir, err := c.GetRepoReleaseBinDir(repoName, args[1])
 				if err != nil {
 					return err
 				}

--- a/client/cmd/trdl/command/md_docs.go
+++ b/client/cmd/trdl/command/md_docs.go
@@ -50,6 +50,11 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer) error {
 		buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", UsageLine(cmd)))
 	}
 
+	if len(cmd.Aliases) > 0 {
+		buf.WriteString("## Aliases\n\n")
+		buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.NameAndAliases()))
+	}
+
 	if len(cmd.Example) > 0 {
 		buf.WriteString("## Examples\n\n")
 		buf.WriteString(fmt.Sprintf("```shell\n%s\n```\n\n", cmd.Example))

--- a/client/cmd/trdl/command/template.go
+++ b/client/cmd/trdl/command/template.go
@@ -16,7 +16,7 @@ const (
 		`{{$versionLine := versionLine .}}`
 
 	// SectionAliases is the help template section that displays command aliases.
-	SectionAliases = `{{if gt .Aliases 0}}Aliases:
+	SectionAliases = `{{if gt (len .Aliases) 0}}Aliases:
 {{.NameAndAliases}}
 
 {{end}}`

--- a/client/cmd/trdl/common.go
+++ b/client/cmd/trdl/common.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/asaskevich/govalidator"
 	"github.com/spf13/cobra"
 
@@ -25,16 +27,11 @@ func ValidateChannel(channel string) error {
 // release version. Versions are distinguished from a GROUP (a plain version
 // number, e.g. "2") by the leading "v" prefix (e.g. "v2.72.0").
 func isVersionArg(arg string) bool {
-	if len(arg) < 2 || arg[0] != 'v' {
+	if len(arg) < 2 || !regexp.MustCompile(`^[<>=~^v]`).MatchString(arg) {
 		return false
 	}
-	return arg[1] >= '0' && arg[1] <= '9'
-}
 
-// parseVersionArg strips the leading "v" prefix from an explicit version
-// argument, returning the bare version passed to the downstream code.
-func parseVersionArg(arg string) string {
-	return arg[1:]
+	return true
 }
 
 // validateVersionArgs enforces that an explicit VERSION argument is mutually
@@ -46,6 +43,11 @@ func validateVersionArgs(cmd *cobra.Command, args []string) error {
 		if len(args) > 2 {
 			return fmt.Errorf("VERSION is mutually exclusive with GROUP and CHANNEL arguments")
 		}
+
+		if _, err := semver.NewConstraint(args[1]); err != nil {
+			return fmt.Errorf("validate version: %w", err)
+		}
+
 		return nil
 	}
 

--- a/client/cmd/trdl/common.go
+++ b/client/cmd/trdl/common.go
@@ -23,25 +23,36 @@ func ValidateChannel(channel string) error {
 	return nil
 }
 
+var explicitVersionPrefixRegexp = regexp.MustCompile(`^v\d`)
+
 // isVersionArg reports whether the given positional argument is an explicit
-// release version. Versions are distinguished from a GROUP (a plain version
-// number, e.g. "2") by the leading "v" prefix (e.g. "v2.72.0").
+// release version rather than a GROUP. An argument is a VERSION when it has a
+// leading "v" prefix followed by a digit (e.g. "v2.72.0") or is a semver
+// constraint (e.g. ">=1.2.0", "1.2.*"). A plain semver number without the "v"
+// prefix (e.g. "1.2") is a GROUP, as is any other name (e.g. "vendor").
 func isVersionArg(arg string) bool {
-	if len(arg) < 2 || !regexp.MustCompile(`^[<>=~^v]`).MatchString(arg) {
+	if explicitVersionPrefixRegexp.MatchString(arg) {
+		return true
+	}
+
+	if _, err := semver.NewVersion(arg); err == nil {
 		return false
 	}
 
-	return true
+	if _, err := semver.NewConstraint(arg); err == nil {
+		return true
+	}
+
+	return false
 }
 
-// validateVersionArgs enforces that an explicit VERSION argument is mutually
-// exclusive with the positional GROUP/CHANNEL arguments. When VERSION is given
-// (args[1] has a "v" prefix), only REPO and VERSION are allowed; otherwise the
-// default RangeArgs(2,3) behavior applies.
+// validateVersionArgs enforces that when an explicit VERSION argument is given
+// only REPO and VERSION are allowed; otherwise the default RangeArgs(2,3)
+// behavior applies.
 func validateVersionArgs(cmd *cobra.Command, args []string) error {
 	if len(args) >= 2 && isVersionArg(args[1]) {
 		if len(args) > 2 {
-			return fmt.Errorf("VERSION is mutually exclusive with GROUP and CHANNEL arguments")
+			return fmt.Errorf("in VERSION mode only REPO and VERSION arguments are allowed")
 		}
 
 		if _, err := semver.NewConstraint(args[1]); err != nil {

--- a/client/cmd/trdl/common.go
+++ b/client/cmd/trdl/common.go
@@ -21,6 +21,37 @@ func ValidateChannel(channel string) error {
 	return nil
 }
 
+// isVersionArg reports whether the given positional argument is an explicit
+// release version. Versions are distinguished from a GROUP (a plain version
+// number, e.g. "2") by the leading "v" prefix (e.g. "v2.72.0").
+func isVersionArg(arg string) bool {
+	if len(arg) < 2 || arg[0] != 'v' {
+		return false
+	}
+	return arg[1] >= '0' && arg[1] <= '9'
+}
+
+// parseVersionArg strips the leading "v" prefix from an explicit version
+// argument, returning the bare version passed to the downstream code.
+func parseVersionArg(arg string) string {
+	return arg[1:]
+}
+
+// validateVersionArgs enforces that an explicit VERSION argument is mutually
+// exclusive with the positional GROUP/CHANNEL arguments. When VERSION is given
+// (args[1] has a "v" prefix), only REPO and VERSION are allowed; otherwise the
+// default RangeArgs(2,3) behavior applies.
+func validateVersionArgs(cmd *cobra.Command, args []string) error {
+	if len(args) >= 2 && isVersionArg(args[1]) {
+		if len(args) > 2 {
+			return fmt.Errorf("VERSION is mutually exclusive with GROUP and CHANNEL arguments")
+		}
+		return nil
+	}
+
+	return cobra.RangeArgs(2, 3)(cmd, args)
+}
+
 func SetupNoSelfUpdate(cmd *cobra.Command, noSelfUpdate *bool) {
 	envKey := "TRDL_NO_SELF_UPDATE"
 

--- a/client/cmd/trdl/common_ai_test.go
+++ b/client/cmd/trdl/common_ai_test.go
@@ -1,0 +1,38 @@
+//go:build ai_tests
+
+package main
+
+import "testing"
+
+func TestAI_isVersionArg(t *testing.T) {
+	tests := []struct {
+		name        string
+		arg         string
+		wantVersion bool
+	}{
+		{name: "plain major is group", arg: "1", wantVersion: false},
+		{name: "plain major.minor is group", arg: "1.2", wantVersion: false},
+		{name: "plain major.minor.patch is group", arg: "1.2.3", wantVersion: false},
+		{name: "plain prerelease is group", arg: "1.2.3-beta", wantVersion: false},
+		{name: "plain build metadata is group", arg: "1.2.3+build", wantVersion: false},
+		{name: "non-semver name is group", arg: "vendor", wantVersion: false},
+
+		{name: "v-prefixed major.minor is version", arg: "v1.2", wantVersion: true},
+		{name: "v-prefixed major is version", arg: "v3", wantVersion: true},
+		{name: "gte constraint is version", arg: ">=1.2.0", wantVersion: true},
+		{name: "x-range constraint is version", arg: "1.2.x", wantVersion: true},
+		{name: "star-range constraint is version", arg: "1.2.*", wantVersion: true},
+		{name: "not-equal constraint is version", arg: "!=1.2.3", wantVersion: true},
+		{name: "tilde constraint is version", arg: "~1.2", wantVersion: true},
+		{name: "caret constraint is version", arg: "^1", wantVersion: true},
+		{name: "or constraint is version", arg: ">=1.0 || <2.0", wantVersion: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isVersionArg(tt.arg); got != tt.wantVersion {
+				t.Fatalf("isVersionArg(%q) = %v, want %v", tt.arg, got, tt.wantVersion)
+			}
+		})
+	}
+}

--- a/client/cmd/trdl/common_test.go
+++ b/client/cmd/trdl/common_test.go
@@ -1,10 +1,8 @@
-//go:build ai_tests
-
 package main
 
 import "testing"
 
-func TestAI_isVersionArg(t *testing.T) {
+func TestIsVersionArg(t *testing.T) {
 	tests := []struct {
 		name        string
 		arg         string

--- a/client/cmd/trdl/dir_path.go
+++ b/client/cmd/trdl/dir_path.go
@@ -11,7 +11,7 @@ import (
 
 func dirPathCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "dir-path REPO GROUP [CHANNEL]",
+		Use:                   "dir-path REPO GROUP [CHANNEL] | REPO VERSION",
 		Short:                 "Get the directory with software artifacts",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/client/cmd/trdl/dir_path.go
+++ b/client/cmd/trdl/dir_path.go
@@ -15,18 +15,35 @@ func dirPathCmd() *cobra.Command {
 		Short:                 "Get the directory with software artifacts",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.RangeArgs(2, 3)(cmd, args); err != nil {
+			if err := validateVersionArgs(cmd, args); err != nil {
 				PrintHelp(cmd)
 				return err
 			}
 
 			repoName := args[0]
-			group := args[1]
 
 			if repoName == trdl.SelfUpdateDefaultRepo {
 				PrintHelp(cmd)
 				return fmt.Errorf("reserved repository name %q cannot be used", trdl.SelfUpdateDefaultRepo)
 			}
+
+			c, err := trdlClient.NewClient(homeDir)
+			if err != nil {
+				return fmt.Errorf("unable to initialize trdl client: %w", err)
+			}
+
+			if isVersionArg(args[1]) {
+				dir, err := c.GetRepoReleaseDir(repoName, args[1])
+				if err != nil {
+					return err
+				}
+
+				fmt.Println(dir)
+
+				return nil
+			}
+
+			group := args[1]
 
 			var optionalChannel string
 			if len(args) == 3 {
@@ -35,11 +52,6 @@ func dirPathCmd() *cobra.Command {
 					PrintHelp(cmd)
 					return err
 				}
-			}
-
-			c, err := trdlClient.NewClient(homeDir)
-			if err != nil {
-				return fmt.Errorf("unable to initialize trdl client: %w", err)
 			}
 
 			dir, err := c.GetRepoChannelReleaseDir(repoName, group, optionalChannel)

--- a/client/cmd/trdl/exec.go
+++ b/client/cmd/trdl/exec.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/spf13/cobra"
 
 	trdlClient "github.com/werf/trdl/client/pkg/client"
@@ -24,7 +25,7 @@ func execCmd() *cobra.Command {
 		Short:                 "Exec a software binary",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := validateVersionArgs(cmd, args); err != nil {
+			if err := cobra.MinimumNArgs(2)(cmd, args); err != nil {
 				PrintHelp(cmd)
 				return err
 			}
@@ -78,6 +79,10 @@ func processExecArgs(cmd *cobra.Command, args []string) (*execCmdData, error) {
 	doubleDashExist := cmd.ArgsLenAtDash() != -1
 
 	if isVersionArg(args[1]) {
+		if _, err := semver.NewConstraint(args[1]); err != nil {
+			return nil, fmt.Errorf("validate version: %w", err)
+		}
+
 		data.version = args[1]
 
 		restArgs := args[2:]

--- a/client/cmd/trdl/exec.go
+++ b/client/cmd/trdl/exec.go
@@ -24,7 +24,7 @@ func execCmd() *cobra.Command {
 		Short:                 "Exec a software binary",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.MinimumNArgs(2)(cmd, args); err != nil {
+			if err := validateVersionArgs(cmd, args); err != nil {
 				PrintHelp(cmd)
 				return err
 			}

--- a/client/cmd/trdl/exec.go
+++ b/client/cmd/trdl/exec.go
@@ -98,7 +98,7 @@ func processExecArgs(cmd *cobra.Command, args []string) (*execCmdData, error) {
 			data.optionalBinaryName = restArgs[0]
 			return data, nil
 		default:
-			return nil, fmt.Errorf("VERSION is mutually exclusive with GROUP and CHANNEL arguments")
+			return nil, fmt.Errorf("exec REPO VERSION accepts at most one BINARY_NAME")
 		}
 	}
 

--- a/client/cmd/trdl/exec.go
+++ b/client/cmd/trdl/exec.go
@@ -11,6 +11,7 @@ import (
 
 type execCmdData struct {
 	repoName           string
+	version            string
 	group              string
 	optionalChannel    string
 	optionalBinaryName string
@@ -19,7 +20,7 @@ type execCmdData struct {
 
 func execCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "exec REPO GROUP [CHANNEL] [BINARY_NAME] [--] [ARGS]",
+		Use:                   "exec REPO GROUP [CHANNEL] [BINARY_NAME] [--] [ARGS] | REPO VERSION [BINARY_NAME] [--] [ARGS]",
 		Short:                 "Exec a software binary",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,6 +38,17 @@ func execCmd() *cobra.Command {
 			c, err := trdlClient.NewClient(homeDir)
 			if err != nil {
 				return fmt.Errorf("unable to initialize trdl client: %w", err)
+			}
+
+			if cmdData.version != "" {
+				if err := c.ExecRepoReleaseBin(
+					cmdData.repoName, cmdData.version,
+					cmdData.optionalBinaryName, cmdData.optionalBinaryArgs,
+				); err != nil {
+					return err
+				}
+
+				return nil
 			}
 
 			if err := c.ExecRepoChannelReleaseBin(
@@ -57,7 +69,6 @@ func processExecArgs(cmd *cobra.Command, args []string) (*execCmdData, error) {
 	data := &execCmdData{}
 
 	data.repoName = args[0]
-	data.group = args[1]
 
 	if data.repoName == trdl.SelfUpdateDefaultRepo {
 		return nil, fmt.Errorf("reserved repository name %q cannot be used", trdl.SelfUpdateDefaultRepo)
@@ -65,6 +76,28 @@ func processExecArgs(cmd *cobra.Command, args []string) (*execCmdData, error) {
 
 	doubleDashInd := cmd.ArgsLenAtDash()
 	doubleDashExist := cmd.ArgsLenAtDash() != -1
+
+	if isVersionArg(args[1]) {
+		data.version = parseVersionArg(args[1])
+
+		restArgs := args[2:]
+		if doubleDashExist {
+			data.optionalBinaryArgs = args[doubleDashInd:]
+			restArgs = args[2:doubleDashInd]
+		}
+
+		switch len(restArgs) {
+		case 0:
+			return data, nil
+		case 1:
+			data.optionalBinaryName = restArgs[0]
+			return data, nil
+		default:
+			return nil, fmt.Errorf("VERSION is mutually exclusive with GROUP and CHANNEL arguments")
+		}
+	}
+
+	data.group = args[1]
 
 	restArgs := args[2:]
 	if doubleDashExist {

--- a/client/cmd/trdl/exec.go
+++ b/client/cmd/trdl/exec.go
@@ -78,7 +78,7 @@ func processExecArgs(cmd *cobra.Command, args []string) (*execCmdData, error) {
 	doubleDashExist := cmd.ArgsLenAtDash() != -1
 
 	if isVersionArg(args[1]) {
-		data.version = parseVersionArg(args[1])
+		data.version = args[1]
 
 		restArgs := args[2:]
 		if doubleDashExist {

--- a/client/cmd/trdl/update.go
+++ b/client/cmd/trdl/update.go
@@ -86,7 +86,7 @@ func updateCmd() *cobra.Command {
 			}
 
 			if isVersion {
-				if err := c.UpdateRepoToVersion(repoName, parseVersionArg(args[1]), autoclean); err != nil {
+				if err := c.UpdateRepoToVersion(repoName, args[1], autoclean); err != nil {
 					return err
 				}
 

--- a/client/cmd/trdl/update.go
+++ b/client/cmd/trdl/update.go
@@ -21,29 +21,34 @@ func updateCmd() *cobra.Command {
 	var backgroundStderrFile string
 
 	cmd := &cobra.Command{
-		Use:                   "update REPO GROUP [CHANNEL]",
+		Use:                   "update REPO GROUP [CHANNEL] | REPO VERSION",
 		Short:                 "Update the software",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.RangeArgs(2, 3)(cmd, args); err != nil {
+			if err := validateVersionArgs(cmd, args); err != nil {
 				PrintHelp(cmd)
 				return err
 			}
 
 			repoName := args[0]
-			group := args[1]
 
 			if repoName == trdl.SelfUpdateDefaultRepo {
 				PrintHelp(cmd)
 				return fmt.Errorf("reserved repository name %q cannot be used", trdl.SelfUpdateDefaultRepo)
 			}
 
+			isVersion := isVersionArg(args[1])
+
+			var group string
 			var optionalChannel string
-			if len(args) == 3 {
-				optionalChannel = args[2]
-				if err := ValidateChannel(optionalChannel); err != nil {
-					PrintHelp(cmd)
-					return err
+			if !isVersion {
+				group = args[1]
+				if len(args) == 3 {
+					optionalChannel = args[2]
+					if err := ValidateChannel(optionalChannel); err != nil {
+						PrintHelp(cmd)
+						return err
+					}
 				}
 			}
 
@@ -78,6 +83,14 @@ func updateCmd() *cobra.Command {
 				if err := c.DoSelfUpdate(autoclean); err != nil {
 					_, _ = fmt.Fprintf(os.Stderr, "WARNING: Self-update failed: %s\n", err)
 				}
+			}
+
+			if isVersion {
+				if err := c.UpdateRepoToVersion(repoName, parseVersionArg(args[1]), autoclean); err != nil {
+					return err
+				}
+
+				return nil
 			}
 
 			if err := c.UpdateRepoChannel(repoName, group, optionalChannel, autoclean); err != nil {

--- a/client/cmd/trdl/update.go
+++ b/client/cmd/trdl/update.go
@@ -22,6 +22,7 @@ func updateCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:                   "update REPO GROUP [CHANNEL] | REPO VERSION",
+		Aliases:               []string{"download"},
 		Short:                 "Update the software",
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/client/cmd/trdl/use.go
+++ b/client/cmd/trdl/use.go
@@ -58,7 +58,7 @@ func useCmd() *cobra.Command {
 			if isVersionArg(args[1]) {
 				scriptPath, err := c.UseRepoReleaseBinDir(
 					repoName,
-					parseVersionArg(args[1]),
+					args[1],
 					shell,
 					repo.UseSourceOptions{NoSelfUpdate: noSelfUpdate},
 				)

--- a/client/cmd/trdl/use.go
+++ b/client/cmd/trdl/use.go
@@ -23,8 +23,7 @@ func useCmd() *cobra.Command {
 		Example: `  # Source script in a shell
   $ . $(trdl use repo_name 1.2 ea)
 
-  # Pin an explicit version instead of a group/channel
-  # (an exact version must be prefixed with "v", otherwise it is treated as a group)
+  # Pin an exact version (prefix it with "v"; a plain number like "1.2" is a GROUP)
   $ . $(trdl use repo_name v1.2.3)
 
   # Pin a semver constraint (resolves to the greatest matching release)

--- a/client/cmd/trdl/use.go
+++ b/client/cmd/trdl/use.go
@@ -17,37 +17,30 @@ func useCmd() *cobra.Command {
 	var shell string
 
 	cmd := &cobra.Command{
-		Use:   "use REPO GROUP [CHANNEL]",
+		Use:   "use REPO GROUP [CHANNEL] | REPO VERSION",
 		Short: "Generate a script to use the software binaries within a shell session",
 		Long:  `Generate a script to update the software binaries in the background and use local ones within a shell session`,
 		Example: `  # Source script in a shell
   $ . $(trdl use repo_name 1.2 ea)
+
+  # Pin an explicit version instead of a group/channel
+  $ . $(trdl use repo_name v1.2.3)
 
   # Force script generation for a Unix shell on Windows
   $ trdl use repo_name 1.2 ea --shell unix
 `,
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := cobra.RangeArgs(2, 3)(cmd, args); err != nil {
+			if err := validateVersionArgs(cmd, args); err != nil {
 				PrintHelp(cmd)
 				return err
 			}
 
 			repoName := args[0]
-			group := args[1]
 
 			if repoName == trdl.SelfUpdateDefaultRepo {
 				PrintHelp(cmd)
 				return fmt.Errorf("reserved repository name %q cannot be used", trdl.SelfUpdateDefaultRepo)
-			}
-
-			var optionalChannel string
-			if len(args) == 3 {
-				optionalChannel = args[2]
-				if err := ValidateChannel(optionalChannel); err != nil {
-					PrintHelp(cmd)
-					return err
-				}
 			}
 
 			switch shell {
@@ -60,6 +53,33 @@ func useCmd() *cobra.Command {
 			c, err := trdlClient.NewClient(homeDir)
 			if err != nil {
 				return fmt.Errorf("unable to initialize trdl client: %w", err)
+			}
+
+			if isVersionArg(args[1]) {
+				scriptPath, err := c.UseRepoReleaseBinDir(
+					repoName,
+					parseVersionArg(args[1]),
+					shell,
+					repo.UseSourceOptions{NoSelfUpdate: noSelfUpdate},
+				)
+				if err != nil {
+					return err
+				}
+
+				fmt.Println(scriptPath)
+
+				return nil
+			}
+
+			group := args[1]
+
+			var optionalChannel string
+			if len(args) == 3 {
+				optionalChannel = args[2]
+				if err := ValidateChannel(optionalChannel); err != nil {
+					PrintHelp(cmd)
+					return err
+				}
 			}
 
 			scriptPath, err := c.UseRepoChannelReleaseBinDir(

--- a/client/cmd/trdl/use.go
+++ b/client/cmd/trdl/use.go
@@ -24,7 +24,11 @@ func useCmd() *cobra.Command {
   $ . $(trdl use repo_name 1.2 ea)
 
   # Pin an explicit version instead of a group/channel
+  # (an exact version must be prefixed with "v", otherwise it is treated as a group)
   $ . $(trdl use repo_name v1.2.3)
+
+  # Pin a semver constraint (resolves to the greatest matching release)
+  $ . $(trdl use repo_name '>=1.2.0')
 
   # Force script generation for a Unix shell on Windows
   $ trdl use repo_name 1.2 ea --shell unix

--- a/client/cmd/trdl/version_flag_ai_test.go
+++ b/client/cmd/trdl/version_flag_ai_test.go
@@ -43,7 +43,7 @@ func TestAI_processExecArgs_versionFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if data.version != "1.2.3" || data.group != "" || data.optionalChannel != "" {
+	if data.version != "v1.2.3" || data.group != "" || data.optionalChannel != "" {
 		t.Fatalf("unexpected data: %+v", data)
 	}
 	if data.optionalBinaryName != "" {
@@ -54,7 +54,7 @@ func TestAI_processExecArgs_versionFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if data.version != "1.2.3" || data.optionalBinaryName != "mybin" {
+	if data.version != "v1.2.3" || data.optionalBinaryName != "mybin" {
 		t.Fatalf("unexpected data: %+v", data)
 	}
 

--- a/client/cmd/trdl/version_flag_ai_test.go
+++ b/client/cmd/trdl/version_flag_ai_test.go
@@ -1,0 +1,84 @@
+//go:build ai_tests
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newTestCmd() *cobra.Command {
+	return &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
+}
+
+func TestAI_validateVersionArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{name: "channel: repo+group ok", args: []string{"repo", "1.2"}, wantErr: false},
+		{name: "channel: repo+group+channel ok", args: []string{"repo", "1.2", "stable"}, wantErr: false},
+		{name: "channel: only repo errors", args: []string{"repo"}, wantErr: true},
+		{name: "channel: too many args errors", args: []string{"repo", "1.2", "stable", "extra"}, wantErr: true},
+		{name: "version: repo+version ok", args: []string{"repo", "v1.2.3"}, wantErr: false},
+		{name: "version: with channel errors (mutual excl)", args: []string{"repo", "v1.2.3", "stable"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVersionArgs(newTestCmd(), tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateVersionArgs(%v) error = %v, wantErr %v", tt.args, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAI_processExecArgs_versionFlow(t *testing.T) {
+	cmd := newTestCmd()
+
+	data, err := processExecArgs(cmd, []string{"repo", "v1.2.3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.version != "1.2.3" || data.group != "" || data.optionalChannel != "" {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+	if data.optionalBinaryName != "" {
+		t.Fatalf("expected no binary name, got %q", data.optionalBinaryName)
+	}
+
+	data, err = processExecArgs(cmd, []string{"repo", "v1.2.3", "mybin"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.version != "1.2.3" || data.optionalBinaryName != "mybin" {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+
+	if _, err := processExecArgs(cmd, []string{"repo", "v1.2.3", "a", "b"}); err == nil {
+		t.Fatalf("expected mutual-exclusivity error for extra positional args")
+	}
+}
+
+func TestAI_processExecArgs_channelFlow(t *testing.T) {
+	cmd := newTestCmd()
+
+	data, err := processExecArgs(cmd, []string{"repo", "1.2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.group != "1.2" || data.version != "" {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+
+	data, err = processExecArgs(cmd, []string{"repo", "1.2", "stable", "mybin"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if data.group != "1.2" || data.optionalChannel != "stable" || data.optionalBinaryName != "mybin" {
+		t.Fatalf("unexpected data: %+v", data)
+	}
+}

--- a/client/cmd/trdl/version_flag_test.go
+++ b/client/cmd/trdl/version_flag_test.go
@@ -1,4 +1,5 @@
-//go:build ai_tests
+//go:build test_coverage
+// +build test_coverage
 
 package main
 
@@ -12,7 +13,7 @@ func newTestCmd() *cobra.Command {
 	return &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error { return nil }}
 }
 
-func TestAI_validateVersionArgs(t *testing.T) {
+func TestValidateVersionArgs(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    []string
@@ -36,7 +37,7 @@ func TestAI_validateVersionArgs(t *testing.T) {
 	}
 }
 
-func TestAI_processExecArgs_versionFlow(t *testing.T) {
+func TestProcessExecArgs_versionFlow(t *testing.T) {
 	cmd := newTestCmd()
 
 	data, err := processExecArgs(cmd, []string{"repo", "v1.2.3"})
@@ -63,7 +64,7 @@ func TestAI_processExecArgs_versionFlow(t *testing.T) {
 	}
 }
 
-func TestAI_processExecArgs_channelFlow(t *testing.T) {
+func TestProcessExecArgs_channelFlow(t *testing.T) {
 	cmd := newTestCmd()
 
 	data, err := processExecArgs(cmd, []string{"repo", "1.2"})

--- a/client/cmd/trdl/version_flag_test.go
+++ b/client/cmd/trdl/version_flag_test.go
@@ -1,6 +1,3 @@
-//go:build test_coverage
-// +build test_coverage
-
 package main
 
 import (

--- a/client/go.mod
+++ b/client/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	bou.ke/monkey v1.0.2
+	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/gookit/color v1.5.4
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf

--- a/client/go.sum
+++ b/client/go.sum
@@ -1,5 +1,7 @@
 bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
 bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/avelino/slugify v0.0.0-20180501145920-855f152bd774 h1:HrMVYtly2IVqg9EBooHsakQ256ueojP7QuG32K71X/U=

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -336,6 +336,11 @@ func (c Client) ExecRepoReleaseBin(repoName, version, optionalBinName string, ar
 		return err
 	}
 
+	err = os.Setenv(repo.FormatRepoVersionConstraintEnvName(repoName), version)
+	if err != nil {
+		return err
+	}
+
 	if err := repoClient.ExecReleaseBin(release, optionalBinName, args); err != nil {
 		switch e := err.(type) {
 		case repo.ReleaseNotFoundLocallyError:

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -250,7 +250,7 @@ func (c Client) doSelfUpdate(autocleanReleases bool) error {
 	}
 
 	if autocleanReleases {
-		if err := repoClient.CleanReleases(""); err != nil {
+		if err := repoClient.CleanReleases(); err != nil {
 			return fmt.Errorf("unable to clean old releases: %w", err)
 		}
 	}
@@ -274,7 +274,7 @@ func (c Client) UpdateRepoChannel(repoName, group, optionalChannel string, autoc
 	}
 
 	if autocleanReleases {
-		if err := repoClient.CleanReleases(""); err != nil {
+		if err := repoClient.CleanReleases(); err != nil {
 			return fmt.Errorf("unable to clean old releases: %w", err)
 		}
 	}
@@ -293,7 +293,7 @@ func (c Client) UpdateRepoToVersion(repoName, version string, autocleanReleases 
 	}
 
 	if autocleanReleases {
-		if err := repoClient.CleanReleases(version); err != nil {
+		if err := repoClient.CleanReleases(); err != nil {
 			return fmt.Errorf("unable to clean old releases: %w", err)
 		}
 	}
@@ -321,13 +321,20 @@ func (c Client) ExecRepoReleaseBin(repoName, version, optionalBinName string, ar
 		return err
 	}
 
+	release, err := repoClient.FindLocalReleaseByVersion(version)
+	if err != nil {
+		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
+			return prepareReleaseNotFoundLocallyErr(e)
+		}
+	}
+
 	// Pass version env to the binary be executed.
-	err = os.Setenv(repo.FormatRepoChannelGroupEnvName(repoName), version)
+	err = os.Setenv(repo.FormatRepoChannelGroupEnvName(repoName), release)
 	if err != nil {
 		return err
 	}
 
-	if err := repoClient.ExecReleaseBin(version, optionalBinName, args); err != nil {
+	if err := repoClient.ExecReleaseBin(release, optionalBinName, args); err != nil {
 		switch e := err.(type) {
 		case repo.ReleaseNotFoundLocallyError:
 			return prepareReleaseNotFoundLocallyErr(e)
@@ -347,7 +354,14 @@ func (c Client) GetRepoReleaseBinDir(repoName, version string) (string, error) {
 		return "", err
 	}
 
-	dir, err := repoClient.GetReleaseBinDir(version)
+	release, err := repoClient.FindLocalReleaseByVersion(version)
+	if err != nil {
+		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
+			return "", prepareReleaseNotFoundLocallyErr(e)
+		}
+	}
+
+	dir, err := repoClient.GetReleaseBinDir(release)
 	if err != nil {
 		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
 			return "", prepareReleaseNotFoundLocallyErr(e)
@@ -432,6 +446,30 @@ func (c Client) GetRepoChannelReleaseDir(repoName, group, optionalChannel string
 		}
 
 		return "", err
+	}
+
+	return dir, nil
+}
+
+func (c Client) GetRepoReleaseDir(repoName, version string) (string, error) {
+	repoClient, err := c.GetRepoClient(repoName)
+	if err != nil {
+		return "", err
+	}
+
+	release, err := repoClient.FindLocalReleaseByVersion(version)
+	if err != nil {
+		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
+			return "", prepareReleaseNotFoundLocallyErr(e)
+		}
+	}
+
+	dir, err := repoClient.GetReleaseDir(release)
+	if err != nil {
+		switch e := err.(type) {
+		case repo.ReleaseNotFoundLocallyError:
+			return "", prepareReleaseNotFoundLocallyErr(e)
+		}
 	}
 
 	return dir, nil

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -326,10 +326,12 @@ func (c Client) ExecRepoReleaseBin(repoName, version, optionalBinName string, ar
 		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
 			return prepareReleaseNotFoundLocallyErr(e)
 		}
+
+		return err
 	}
 
 	// Pass version env to the binary be executed.
-	err = os.Setenv(repo.FormatRepoChannelGroupEnvName(repoName), release)
+	err = os.Setenv(repo.FormatRepoVersionEnvName(repoName), release)
 	if err != nil {
 		return err
 	}
@@ -359,6 +361,8 @@ func (c Client) GetRepoReleaseBinDir(repoName, version string) (string, error) {
 		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
 			return "", prepareReleaseNotFoundLocallyErr(e)
 		}
+
+		return "", err
 	}
 
 	dir, err := repoClient.GetReleaseBinDir(release)
@@ -462,14 +466,17 @@ func (c Client) GetRepoReleaseDir(repoName, version string) (string, error) {
 		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
 			return "", prepareReleaseNotFoundLocallyErr(e)
 		}
+
+		return "", err
 	}
 
 	dir, err := repoClient.GetReleaseDir(release)
 	if err != nil {
-		switch e := err.(type) {
-		case repo.ReleaseNotFoundLocallyError:
+		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
 			return "", prepareReleaseNotFoundLocallyErr(e)
 		}
+
+		return "", err
 	}
 
 	return dir, nil

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -250,7 +250,7 @@ func (c Client) doSelfUpdate(autocleanReleases bool) error {
 	}
 
 	if autocleanReleases {
-		if err := repoClient.CleanReleases(); err != nil {
+		if err := repoClient.CleanReleases(""); err != nil {
 			return fmt.Errorf("unable to clean old releases: %w", err)
 		}
 	}
@@ -274,7 +274,7 @@ func (c Client) UpdateRepoChannel(repoName, group, optionalChannel string, autoc
 	}
 
 	if autocleanReleases {
-		if err := repoClient.CleanReleases(); err != nil {
+		if err := repoClient.CleanReleases(""); err != nil {
 			return fmt.Errorf("unable to clean old releases: %w", err)
 		}
 	}
@@ -293,8 +293,7 @@ func (c Client) UpdateRepoToVersion(repoName, version string, autocleanReleases 
 	}
 
 	if autocleanReleases {
-		// Should we ignore specific version?
-		if err := repoClient.CleanReleases(); err != nil {
+		if err := repoClient.CleanReleases(version); err != nil {
 			return fmt.Errorf("unable to clean old releases: %w", err)
 		}
 	}
@@ -486,7 +485,7 @@ func prepareChannelReleaseNotFoundLocallyErr(e repo.ChannelReleaseNotFoundLocall
 
 func prepareReleaseNotFoundLocallyErr(e repo.ReleaseNotFoundLocallyError) error {
 	return fmt.Errorf(
-		"%w, update version with \"trdl update %s --version=%s\" command",
+		"%w, update version with \"trdl update %s v%s\" command",
 		e,
 		e.RepoName,
 		e.Version,

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -530,7 +530,7 @@ func prepareChannelReleaseNotFoundLocallyErr(e repo.ChannelReleaseNotFoundLocall
 
 func prepareReleaseNotFoundLocallyErr(e repo.ReleaseNotFoundLocallyError) error {
 	return fmt.Errorf(
-		"%w, update version with \"trdl update %s v%s\" command",
+		"%w, update version with \"trdl update %s %s\" command",
 		e,
 		e.RepoName,
 		e.Version,

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -282,6 +282,84 @@ func (c Client) UpdateRepoChannel(repoName, group, optionalChannel string, autoc
 	return nil
 }
 
+func (c Client) UpdateRepoToVersion(repoName, version string, autocleanReleases bool) error {
+	repoClient, err := c.GetRepoClient(repoName)
+	if err != nil {
+		return err
+	}
+
+	if err := repoClient.UpdateToVersion(version); err != nil {
+		return err
+	}
+
+	if autocleanReleases {
+		// Should we ignore specific version?
+		if err := repoClient.CleanReleases(); err != nil {
+			return fmt.Errorf("unable to clean old releases: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c Client) UseRepoReleaseBinDir(repoName, version, shell string, opts repo.UseSourceOptions) (string, error) {
+	repoClient, err := c.GetRepoClient(repoName)
+	if err != nil {
+		return "", err
+	}
+
+	scriptPath, err := repoClient.UseReleaseBinDir(version, shell, opts)
+	if err != nil {
+		return "", err
+	}
+
+	return scriptPath, nil
+}
+
+func (c Client) ExecRepoReleaseBin(repoName, version, optionalBinName string, args []string) error {
+	repoClient, err := c.GetRepoClient(repoName)
+	if err != nil {
+		return err
+	}
+
+	// Pass version env to the binary be executed.
+	err = os.Setenv(repo.FormatRepoChannelGroupEnvName(repoName), version)
+	if err != nil {
+		return err
+	}
+
+	if err := repoClient.ExecReleaseBin(version, optionalBinName, args); err != nil {
+		switch e := err.(type) {
+		case repo.ReleaseNotFoundLocallyError:
+			return prepareReleaseNotFoundLocallyErr(e)
+		case repo.ReleaseBinSeveralFilesFoundError:
+			return prepareReleaseBinSeveralFilesFoundErr(e)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (c Client) GetRepoReleaseBinDir(repoName, version string) (string, error) {
+	repoClient, err := c.GetRepoClient(repoName)
+	if err != nil {
+		return "", err
+	}
+
+	dir, err := repoClient.GetReleaseBinDir(version)
+	if err != nil {
+		if e, ok := err.(repo.ReleaseNotFoundLocallyError); ok {
+			return "", prepareReleaseNotFoundLocallyErr(e)
+		}
+
+		return "", err
+	}
+
+	return dir, nil
+}
+
 func (c Client) UseRepoChannelReleaseBinDir(repoName, group, optionalChannel, shell string, opts repo.UseSourceOptions) (string, error) {
 	channel, err := c.processRepoOptionalChannel(repoName, optionalChannel)
 	if err != nil {
@@ -403,6 +481,23 @@ func prepareChannelReleaseNotFoundLocallyErr(e repo.ChannelReleaseNotFoundLocall
 		e.RepoName,
 		e.Group,
 		e.Channel,
+	)
+}
+
+func prepareReleaseNotFoundLocallyErr(e repo.ReleaseNotFoundLocallyError) error {
+	return fmt.Errorf(
+		"%w, update version with \"trdl update %s --version=%s\" command",
+		e,
+		e.RepoName,
+		e.Version,
+	)
+}
+
+func prepareReleaseBinSeveralFilesFoundErr(e repo.ReleaseBinSeveralFilesFoundError) error {
+	return fmt.Errorf(
+		"%w: it is necessary to specify the certain name:\n - %s",
+		e,
+		strings.Join(e.Names, "\n - "),
 	)
 }
 

--- a/client/pkg/client/client.go
+++ b/client/pkg/client/client.go
@@ -330,7 +330,8 @@ func (c Client) ExecRepoReleaseBin(repoName, version, optionalBinName string, ar
 		return err
 	}
 
-	// Pass version env to the binary be executed.
+	// Pass version env to the binary to be executed, clearing any group/channel
+	// env inherited from a previous selection so telemetry sees a single mode.
 	err = os.Setenv(repo.FormatRepoVersionEnvName(repoName), release)
 	if err != nil {
 		return err
@@ -338,6 +339,10 @@ func (c Client) ExecRepoReleaseBin(repoName, version, optionalBinName string, ar
 
 	err = os.Setenv(repo.FormatRepoVersionConstraintEnvName(repoName), version)
 	if err != nil {
+		return err
+	}
+
+	if err := os.Unsetenv(repo.FormatRepoChannelGroupEnvName(repoName)); err != nil {
 		return err
 	}
 
@@ -412,9 +417,18 @@ func (c Client) ExecRepoChannelReleaseBin(repoName, group, optionalChannel, opti
 		return err
 	}
 
-	// Pass group channel env to the binary be executed.
+	// Pass group/channel env to the binary to be executed, clearing any version
+	// env inherited from a previous selection so telemetry sees a single mode.
 	err = os.Setenv(repo.FormatRepoChannelGroupEnvName(repoName), fmt.Sprintf("%s %s", group, channel))
 	if err != nil {
+		return err
+	}
+
+	if err := os.Unsetenv(repo.FormatRepoVersionEnvName(repoName)); err != nil {
+		return err
+	}
+
+	if err := os.Unsetenv(repo.FormatRepoVersionConstraintEnvName(repoName)); err != nil {
 		return err
 	}
 

--- a/client/pkg/client/interface.go
+++ b/client/pkg/client/interface.go
@@ -12,6 +12,10 @@ type Interface interface {
 	ExecRepoChannelReleaseBin(repoName, group, optionalChannel, optionalBinName string, args []string) error
 	GetRepoChannelReleaseDir(repoName, group, optionalChannel string) (string, error)
 	GetRepoChannelReleaseBinDir(repoName, group, optionalChannel string) (string, error)
+	UpdateRepoToVersion(repoName, version string, autocleanReleases bool) error
+	UseRepoReleaseBinDir(repoName, version, shell string, opts repo.UseSourceOptions) (string, error)
+	ExecRepoReleaseBin(repoName, version, optionalBinName string, args []string) error
+	GetRepoReleaseBinDir(repoName, version string) (string, error)
 	GetRepoList() []*RepoConfiguration
 	GetRepoClient(repoName string) (RepoInterface, error)
 }
@@ -25,6 +29,12 @@ type RepoInterface interface {
 	GetChannelReleaseDir(group, channel string) (string, error)
 	GetChannelReleaseBinDir(group, channel string) (string, error)
 	GetChannelReleaseBinPath(group, channel, optionalBinName string) (string, error)
+	UpdateToVersion(version string) error
+	UseReleaseBinDir(version, shell string, opts repo.UseSourceOptions) (string, error)
+	ExecReleaseBin(version, optionalBinName string, args []string) error
+	GetReleaseDir(version string) (string, error)
+	GetReleaseBinDir(version string) (string, error)
+	GetReleaseBinPath(version, optionalBinName string) (string, error)
 	CleanReleases() error
 }
 

--- a/client/pkg/client/interface.go
+++ b/client/pkg/client/interface.go
@@ -16,6 +16,7 @@ type Interface interface {
 	UseRepoReleaseBinDir(repoName, version, shell string, opts repo.UseSourceOptions) (string, error)
 	ExecRepoReleaseBin(repoName, version, optionalBinName string, args []string) error
 	GetRepoReleaseBinDir(repoName, version string) (string, error)
+	GetRepoReleaseDir(repoName, version string) (string, error)
 	GetRepoList() []*RepoConfiguration
 	GetRepoClient(repoName string) (RepoInterface, error)
 }
@@ -35,7 +36,8 @@ type RepoInterface interface {
 	GetReleaseDir(version string) (string, error)
 	GetReleaseBinDir(version string) (string, error)
 	GetReleaseBinPath(version, optionalBinName string) (string, error)
-	CleanReleases(ignoreVersion string) error
+	CleanReleases() error
+	FindLocalReleaseByVersion(version string) (string, error)
 }
 
 type configurationInterface interface {

--- a/client/pkg/client/interface.go
+++ b/client/pkg/client/interface.go
@@ -35,7 +35,7 @@ type RepoInterface interface {
 	GetReleaseDir(version string) (string, error)
 	GetReleaseBinDir(version string) (string, error)
 	GetReleaseBinPath(version, optionalBinName string) (string, error)
-	CleanReleases() error
+	CleanReleases(ignoreVersion string) error
 }
 
 type configurationInterface interface {

--- a/client/pkg/repo/bin_path.go
+++ b/client/pkg/repo/bin_path.go
@@ -22,3 +22,33 @@ func (c Client) GetChannelReleaseBinPath(group, channel, optionalBinName string)
 
 	return
 }
+
+func (c Client) GetReleaseBinDir(version string) (dir string, err error) {
+	err = lockgate.WithAcquire(c.locker, c.updateReleaseLockName(version), lockgate.AcquireOptions{Shared: true, Timeout: trdl.DefaultLockerTimeout}, func(_ bool) error {
+		dir, err = c.findReleaseBinDir(version)
+		return err
+	})
+
+	return
+}
+
+func (c Client) GetReleaseBinPath(version, optionalBinName string) (path string, err error) {
+	err = lockgate.WithAcquire(c.locker, c.updateReleaseLockName(version), lockgate.AcquireOptions{Shared: true, Timeout: trdl.DefaultLockerTimeout}, func(_ bool) error {
+		binDir, err := c.findReleaseBinDir(version)
+		if err != nil {
+			return err
+		}
+
+		path, err = c.findBinPathInDir(binDir, optionalBinName)
+		if err != nil {
+			if e, ok := err.(ReleaseBinSeveralFilesFoundError); ok {
+				return NewReleaseBinSeveralFilesFoundError(c.repoName, version, e.Names)
+			}
+			return err
+		}
+
+		return nil
+	})
+
+	return
+}

--- a/client/pkg/repo/clean_releases.go
+++ b/client/pkg/repo/clean_releases.go
@@ -11,7 +11,7 @@ import (
 
 var releaseMetafileExpirationPeriod = time.Hour * 24
 
-func (c Client) CleanReleases(ignoreVersion string) error {
+func (c Client) CleanReleases() error {
 	actualLocalReleases, err := c.getActualLocalReleases()
 	if err != nil {
 		return fmt.Errorf("unable to get actual local releases: %w", err)
@@ -39,7 +39,12 @@ func (c Client) CleanReleases(ignoreVersion string) error {
 				return err
 			}
 
-			if isRecentlyUsed || releaseName == ignoreVersion {
+			pinnedVersion, err := c.versionMetafile(releaseName).Exists(c.locker)
+			if err != nil {
+				return fmt.Errorf("ensure version metafile: %w", err)
+			}
+
+			if isRecentlyUsed || pinnedVersion {
 				continue
 			}
 

--- a/client/pkg/repo/clean_releases.go
+++ b/client/pkg/repo/clean_releases.go
@@ -11,7 +11,7 @@ import (
 
 var releaseMetafileExpirationPeriod = time.Hour * 24
 
-func (c Client) CleanReleases() error {
+func (c Client) CleanReleases(ignoreVersion string) error {
 	actualLocalReleases, err := c.getActualLocalReleases()
 	if err != nil {
 		return fmt.Errorf("unable to get actual local releases: %w", err)
@@ -39,7 +39,7 @@ func (c Client) CleanReleases() error {
 				return err
 			}
 
-			if isRecentlyUsed {
+			if isRecentlyUsed || releaseName == ignoreVersion {
 				continue
 			}
 

--- a/client/pkg/repo/client.go
+++ b/client/pkg/repo/client.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/werf/lockgate"
 	"github.com/werf/lockgate/pkg/file_locker"
 	"github.com/werf/trdl/client/pkg/tuf"
@@ -108,7 +109,7 @@ func (c Client) channelScriptsDir(group, channel string) string {
 }
 
 func (c Client) versionScriptsDir(version string) string {
-	return filepath.Join(c.dir, scriptsDir, "v"+version)
+	return filepath.Join(c.dir, scriptsDir, slugifyConstraint(version))
 }
 
 func (c Client) channelTmpPath(group, channel string) string {
@@ -124,7 +125,7 @@ func (c Client) channelScriptsTmpDir(group, channel string) string {
 }
 
 func (c Client) versionScriptsTmpDir(version string) string {
-	return filepath.Join(c.tmpDir, scriptsDir, "v"+version)
+	return filepath.Join(c.tmpDir, scriptsDir, slugifyConstraint(version))
 }
 
 func (c Client) findChannelReleaseBinPath(group, channel, optionalBinName string) (string, error) {
@@ -309,4 +310,44 @@ func (c Client) updateReleaseLockName(release string) string {
 func (c Client) releaseMetafile(release string) util.Metafile {
 	filePath := filepath.Join(c.metafileDir, "releases", release)
 	return util.NewMetafile(filePath)
+}
+
+func (c Client) versionMetafile(version string) util.Metafile {
+	filePath := filepath.Join(c.metafileDir, "versions", version)
+	return util.NewMetafile(filePath)
+}
+
+func (c Client) FindLocalReleaseByVersion(version string) (string, error) {
+	dirGlob := filepath.Join(c.metafileDir, "versions", "*")
+
+	matches, err := filepath.Glob(dirGlob)
+	if err != nil {
+		return "", fmt.Errorf("glob files: %w", err)
+	}
+
+	constraint, err := semver.NewConstraint(version)
+	if err != nil {
+		return "", fmt.Errorf("parse semver constraint %q: %w", version, err)
+	}
+
+	var lastValid *semver.Version
+	for _, file := range matches {
+		releaseName := strings.TrimPrefix(file, filepath.Join(c.metafileDir, "versions")+string(os.PathSeparator))
+		releaseVersion, err := semver.NewVersion(releaseName)
+		if err != nil {
+			return "", fmt.Errorf("parse semver version %q: %w", releaseName, err)
+		}
+
+		if constraint.Check(releaseVersion) {
+			if lastValid == nil || releaseVersion.GreaterThan(lastValid) {
+				lastValid = releaseVersion
+			}
+		}
+	}
+
+	if lastValid == nil {
+		return "", NewReleaseNotFoundLocallyError(c.repoName, version)
+	}
+
+	return lastValid.String(), nil
 }

--- a/client/pkg/repo/client.go
+++ b/client/pkg/repo/client.go
@@ -239,10 +239,6 @@ func (c Client) findReleaseBinDir(release string) (dir string, err error) {
 }
 
 func (c Client) findReleaseDir(release string) (dir string, err error) {
-	if err := c.releaseMetafile(release).Reset(c.locker); err != nil {
-		return "", fmt.Errorf("unable to reset release metafile: %w", err)
-	}
-
 	dirGlob := filepath.Join(c.dir, releasesDir, release, "*")
 
 	matches, err := filepath.Glob(dirGlob)

--- a/client/pkg/repo/client.go
+++ b/client/pkg/repo/client.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+
 	"github.com/werf/lockgate"
 	"github.com/werf/lockgate/pkg/file_locker"
 	"github.com/werf/trdl/client/pkg/tuf"

--- a/client/pkg/repo/client.go
+++ b/client/pkg/repo/client.go
@@ -333,7 +333,7 @@ func (c Client) FindLocalReleaseByVersion(version string) (string, error) {
 		releaseName := strings.TrimPrefix(file, filepath.Join(c.metafileDir, "versions")+string(os.PathSeparator))
 		releaseVersion, err := semver.NewVersion(releaseName)
 		if err != nil {
-			return "", fmt.Errorf("parse semver version %q: %w", releaseName, err)
+			continue
 		}
 
 		if constraint.Check(releaseVersion) {

--- a/client/pkg/repo/client.go
+++ b/client/pkg/repo/client.go
@@ -107,6 +107,10 @@ func (c Client) channelScriptsDir(group, channel string) string {
 	return filepath.Join(c.dir, scriptsDir, strings.Join([]string{group, channel}, "-"))
 }
 
+func (c Client) versionScriptsDir(version string) string {
+	return filepath.Join(c.dir, scriptsDir, strings.Join([]string{"version", version}, "-"))
+}
+
 func (c Client) channelTmpPath(group, channel string) string {
 	return filepath.Join(c.tmpDir, channelsDir, group, channel)
 }
@@ -119,12 +123,70 @@ func (c Client) channelScriptsTmpDir(group, channel string) string {
 	return filepath.Join(c.tmpDir, scriptsDir, strings.Join([]string{group, channel}, "-"))
 }
 
+func (c Client) versionScriptsTmpDir(version string) string {
+	return filepath.Join(c.tmpDir, scriptsDir, strings.Join([]string{"version", version}, "-"))
+}
+
 func (c Client) findChannelReleaseBinPath(group, channel, optionalBinName string) (string, error) {
-	dir, releaseName, err := c.findChannelReleaseBinDir(group, channel)
+	release, err := c.GetChannelRelease(group, channel)
 	if err != nil {
 		return "", err
 	}
 
+	dir, err := c.findReleaseBinDir(release)
+	if err != nil {
+		if _, ok := err.(ReleaseNotFoundLocallyError); ok {
+			return "", NewChannelReleaseNotFoundLocallyError(c.repoName, group, channel, release)
+		}
+		return "", err
+	}
+
+	path, err := c.findBinPathInDir(dir, optionalBinName)
+	if err != nil {
+		if e, ok := err.(ReleaseBinSeveralFilesFoundError); ok {
+			return "", NewChannelReleaseSeveralFilesFoundError(c.repoName, group, channel, release, e.Names)
+		}
+		return "", err
+	}
+
+	return path, nil
+}
+
+func (c Client) findChannelReleaseBinDir(group, channel string) (dir, release string, err error) {
+	release, err = c.GetChannelRelease(group, channel)
+	if err != nil {
+		return "", "", err
+	}
+
+	binDir, err := c.findReleaseBinDir(release)
+	if err != nil {
+		if _, ok := err.(ReleaseNotFoundLocallyError); ok {
+			return "", "", NewChannelReleaseNotFoundLocallyError(c.repoName, group, channel, release)
+		}
+		return "", "", err
+	}
+
+	return binDir, release, nil
+}
+
+func (c Client) findChannelReleaseDir(group, channel string) (dir, release string, err error) {
+	release, err = c.GetChannelRelease(group, channel)
+	if err != nil {
+		return "", "", err
+	}
+
+	dir, err = c.findReleaseDir(release)
+	if err != nil {
+		if _, ok := err.(ReleaseNotFoundLocallyError); ok {
+			return "", "", NewChannelReleaseNotFoundLocallyError(c.repoName, group, channel, release)
+		}
+		return "", "", err
+	}
+
+	return dir, release, nil
+}
+
+func (c Client) findBinPathInDir(dir, optionalBinName string) (string, error) {
 	var glob string
 	if optionalBinName == "" {
 		glob = filepath.Join(dir, "*")
@@ -143,7 +205,7 @@ func (c Client) findChannelReleaseBinPath(group, channel, optionalBinName string
 			names = append(names, strings.TrimPrefix(m, dir+string(os.PathSeparator)))
 		}
 
-		return "", NewChannelReleaseSeveralFilesFoundError(c.repoName, group, channel, releaseName, names)
+		return "", ReleaseBinSeveralFilesFoundError{Names: names}
 	} else if len(matches) == 0 {
 		if optionalBinName == "" {
 			return "", fmt.Errorf("binary file not found in release")
@@ -155,45 +217,44 @@ func (c Client) findChannelReleaseBinPath(group, channel, optionalBinName string
 	return matches[0], nil
 }
 
-func (c Client) findChannelReleaseBinDir(group, channel string) (dir, release string, err error) {
-	releaseDir, releaseName, err := c.findChannelReleaseDir(group, channel)
+func (c Client) findReleaseBinDir(release string) (dir string, err error) {
+	releaseDir, err := c.findReleaseDir(release)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	binDir := filepath.Join(releaseDir, "bin")
 	exist, err := util.IsDirExist(binDir)
 	if err != nil {
-		return "", "", fmt.Errorf("unable to check existence of directory %q: %w", binDir, err)
+		return "", fmt.Errorf("unable to check existence of directory %q: %w", binDir, err)
 	}
 
 	if !exist {
-		return "", "", fmt.Errorf("bin directory not found in the release %q directory (group: %q, channel: %q)", releaseName, group, channel)
+		return "", fmt.Errorf("bin directory not found in the version %q directory", release)
 	}
 
-	return binDir, releaseName, nil
+	return binDir, nil
 }
 
-func (c Client) findChannelReleaseDir(group, channel string) (dir, release string, err error) {
-	release, err = c.GetChannelRelease(group, channel)
-	if err != nil {
-		return "", "", err
+func (c Client) findReleaseDir(release string) (dir string, err error) {
+	if err := c.releaseMetafile(release).Reset(c.locker); err != nil {
+		return "", fmt.Errorf("unable to reset release metafile: %w", err)
 	}
 
 	dirGlob := filepath.Join(c.dir, releasesDir, release, "*")
 
 	matches, err := filepath.Glob(dirGlob)
 	if err != nil {
-		return "", "", fmt.Errorf("unable to glob files: %w", err)
+		return "", fmt.Errorf("unable to glob files: %w", err)
 	}
 
 	if len(matches) > 1 {
-		return "", "", fmt.Errorf("unexpected files in release directory:\n - %s", strings.Join(matches, "\n - "))
+		return "", fmt.Errorf("unexpected files in release directory:\n - %s", strings.Join(matches, "\n - "))
 	} else if len(matches) == 0 {
-		return "", "", NewChannelReleaseNotFoundLocallyError(c.repoName, group, channel, release)
+		return "", NewReleaseNotFoundLocallyError(c.repoName, release)
 	}
 
-	return matches[0], release, nil
+	return matches[0], nil
 }
 
 func (c Client) GetChannelRelease(group, channel string) (string, error) {

--- a/client/pkg/repo/client.go
+++ b/client/pkg/repo/client.go
@@ -108,7 +108,7 @@ func (c Client) channelScriptsDir(group, channel string) string {
 }
 
 func (c Client) versionScriptsDir(version string) string {
-	return filepath.Join(c.dir, scriptsDir, strings.Join([]string{"version", version}, "-"))
+	return filepath.Join(c.dir, scriptsDir, "v"+version)
 }
 
 func (c Client) channelTmpPath(group, channel string) string {
@@ -124,7 +124,7 @@ func (c Client) channelScriptsTmpDir(group, channel string) string {
 }
 
 func (c Client) versionScriptsTmpDir(version string) string {
-	return filepath.Join(c.tmpDir, scriptsDir, strings.Join([]string{"version", version}, "-"))
+	return filepath.Join(c.tmpDir, scriptsDir, "v"+version)
 }
 
 func (c Client) findChannelReleaseBinPath(group, channel, optionalBinName string) (string, error) {

--- a/client/pkg/repo/client.go
+++ b/client/pkg/repo/client.go
@@ -328,6 +328,7 @@ func (c Client) FindLocalReleaseByVersion(version string) (string, error) {
 	}
 
 	var lastValid *semver.Version
+	var lastValidName string
 	for _, file := range matches {
 		releaseName := strings.TrimPrefix(file, filepath.Join(c.metafileDir, "versions")+string(os.PathSeparator))
 		releaseVersion, err := semver.NewVersion(releaseName)
@@ -338,6 +339,7 @@ func (c Client) FindLocalReleaseByVersion(version string) (string, error) {
 		if constraint.Check(releaseVersion) {
 			if lastValid == nil || releaseVersion.GreaterThan(lastValid) {
 				lastValid = releaseVersion
+				lastValidName = releaseName
 			}
 		}
 	}
@@ -346,5 +348,5 @@ func (c Client) FindLocalReleaseByVersion(version string) (string, error) {
 		return "", NewReleaseNotFoundLocallyError(c.repoName, version)
 	}
 
-	return lastValid.String(), nil
+	return lastValidName, nil
 }

--- a/client/pkg/repo/dir_path.go
+++ b/client/pkg/repo/dir_path.go
@@ -13,3 +13,12 @@ func (c Client) GetChannelReleaseDir(group, channel string) (dir string, err err
 
 	return
 }
+
+func (c Client) GetReleaseDir(version string) (dir string, err error) {
+	err = lockgate.WithAcquire(c.locker, c.updateReleaseLockName(version), lockgate.AcquireOptions{Shared: true, Timeout: trdl.DefaultLockerTimeout}, func(_ bool) error {
+		dir, err = c.findReleaseDir(version)
+		return err
+	})
+
+	return
+}

--- a/client/pkg/repo/errors.go
+++ b/client/pkg/repo/errors.go
@@ -61,3 +61,37 @@ func NewChannelReleaseSeveralFilesFoundError(repoName, group, channel, release s
 func (e ChannelReleaseBinSeveralFilesFoundError) Error() string {
 	return fmt.Sprintf("several binary files found in release %q (group: %q, channel: %q)", e.Release, e.Group, e.Channel)
 }
+
+type ReleaseNotFoundLocallyError struct {
+	RepoName string
+	Version  string
+}
+
+func NewReleaseNotFoundLocallyError(repoName, version string) error {
+	return ReleaseNotFoundLocallyError{
+		RepoName: repoName,
+		Version:  version,
+	}
+}
+
+func (e ReleaseNotFoundLocallyError) Error() string {
+	return fmt.Sprintf("version %q not found locally", e.Version)
+}
+
+type ReleaseBinSeveralFilesFoundError struct {
+	RepoName string
+	Version  string
+	Names    []string
+}
+
+func NewReleaseBinSeveralFilesFoundError(repoName, version string, names []string) error {
+	return ReleaseBinSeveralFilesFoundError{
+		RepoName: repoName,
+		Version:  version,
+		Names:    names,
+	}
+}
+
+func (e ReleaseBinSeveralFilesFoundError) Error() string {
+	return fmt.Sprintf("several binary files found in version %q", e.Version)
+}

--- a/client/pkg/repo/exec_path.go
+++ b/client/pkg/repo/exec_path.go
@@ -16,3 +16,22 @@ func (c Client) ExecChannelReleaseBin(group, channel, optionalBinName string, ar
 		return util.Exec(path, args)
 	})
 }
+
+func (c Client) ExecReleaseBin(version, optionalBinName string, args []string) error {
+	return lockgate.WithAcquire(c.locker, c.updateReleaseLockName(version), lockgate.AcquireOptions{Shared: true, Timeout: trdl.DefaultLockerTimeout}, func(_ bool) error {
+		binDir, err := c.findReleaseBinDir(version)
+		if err != nil {
+			return err
+		}
+
+		path, err := c.findBinPathInDir(binDir, optionalBinName)
+		if err != nil {
+			if e, ok := err.(ReleaseBinSeveralFilesFoundError); ok {
+				return NewReleaseBinSeveralFilesFoundError(c.repoName, version, e.Names)
+			}
+			return err
+		}
+
+		return util.Exec(path, args)
+	})
+}

--- a/client/pkg/repo/update.go
+++ b/client/pkg/repo/update.go
@@ -281,7 +281,7 @@ func (c Client) findRelease(version string) (string, error) {
 
 		releaseVersion, err := semver.NewVersion(versionPart)
 		if err != nil {
-			return "", fmt.Errorf("parse semver version %q: %w", name, err)
+			continue
 		}
 
 		if constraint.Check(releaseVersion) {

--- a/client/pkg/repo/update.go
+++ b/client/pkg/repo/update.go
@@ -271,6 +271,7 @@ func (c Client) findRelease(version string) (string, error) {
 	}
 
 	var latestValid *semver.Version
+	var latestValidName string
 	for name := range targets {
 		if !strings.HasPrefix(name, releasesDir+"/") {
 			continue
@@ -286,6 +287,7 @@ func (c Client) findRelease(version string) (string, error) {
 		if constraint.Check(releaseVersion) {
 			if latestValid == nil || releaseVersion.GreaterThan(latestValid) {
 				latestValid = releaseVersion
+				latestValidName = versionPart
 			}
 		}
 	}
@@ -294,7 +296,7 @@ func (c Client) findRelease(version string) (string, error) {
 		return "", fmt.Errorf("unable to find release for version %q", version)
 	}
 
-	return latestValid.String(), nil
+	return latestValidName, nil
 }
 
 func isLocalFileUpToDate(path string, targetMeta data.TargetFileMeta) (bool, error) {

--- a/client/pkg/repo/update.go
+++ b/client/pkg/repo/update.go
@@ -98,6 +98,14 @@ func (c Client) UpdateChannel(group, channel string) error {
 	})
 }
 
+func (c Client) UpdateToVersion(version string) error {
+	if err := c.tufClient.Update(); err != nil {
+		return err
+	}
+
+	return c.syncChannelReleaseWithLock(version)
+}
+
 func (c Client) syncChannelReleaseWithLock(release string) error {
 	return lockgate.WithAcquire(c.locker, c.updateReleaseLockName(release), lockgate.AcquireOptions{Shared: false, Timeout: time.Minute * 5}, func(_ bool) error {
 		return c.syncChannelRelease(release)
@@ -199,7 +207,7 @@ func (c Client) selectAppropriateReleaseTargets(release string) (targets data.Ta
 
 	if len(targets) == 0 {
 		return nil, "", fmt.Errorf(
-			"channel release %q not found in the repository (os: %q, arch: %q)",
+			"version %q not found in the repository (os: %q, arch: %q)",
 			release, runtime.GOOS, runtime.GOARCH,
 		)
 	}

--- a/client/pkg/repo/update.go
+++ b/client/pkg/repo/update.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/theupdateframework/go-tuf/data"
 	util2 "github.com/theupdateframework/go-tuf/util"
 
@@ -103,7 +104,20 @@ func (c Client) UpdateToVersion(version string) error {
 		return err
 	}
 
-	return c.syncChannelReleaseWithLock(version)
+	release, err := c.findRelease(version)
+	if err != nil {
+		return fmt.Errorf("find release: %w", err)
+	}
+
+	if err := c.syncChannelReleaseWithLock(release); err != nil {
+		return fmt.Errorf("sync channel release: %w", err)
+	}
+
+	if err := c.versionMetafile(release).Reset(c.locker); err != nil {
+		return fmt.Errorf("reset version metafile: %w", err)
+	}
+
+	return nil
 }
 
 func (c Client) syncChannelReleaseWithLock(release string) error {
@@ -243,6 +257,44 @@ func (c Client) filterTargets(prefix string) (data.TargetFiles, error) {
 	}
 
 	return result, nil
+}
+
+func (c Client) findRelease(version string) (string, error) {
+	targets, err := c.tufClient.GetTargets()
+	if err != nil {
+		return "", fmt.Errorf("get targets: %w", err)
+	}
+
+	constraint, err := semver.NewConstraint(version)
+	if err != nil {
+		return "", fmt.Errorf("parse semver constraint %q: %w", version, err)
+	}
+
+	var latestValid *semver.Version
+	for name, _ := range targets {
+		if !strings.HasPrefix(name, releasesDir+"/") {
+			continue
+		}
+
+		versionPart := strings.Split(name, "/")[1]
+
+		releaseVersion, err := semver.NewVersion(versionPart)
+		if err != nil {
+			return "", fmt.Errorf("parse semver version %q: %w", name, err)
+		}
+
+		if constraint.Check(releaseVersion) {
+			if latestValid == nil || releaseVersion.GreaterThan(latestValid) {
+				latestValid = releaseVersion
+			}
+		}
+	}
+
+	if latestValid == nil {
+		return "", fmt.Errorf("unable to find release for version %q", version)
+	}
+
+	return latestValid.String(), nil
 }
 
 func isLocalFileUpToDate(path string, targetMeta data.TargetFileMeta) (bool, error) {

--- a/client/pkg/repo/update.go
+++ b/client/pkg/repo/update.go
@@ -271,7 +271,7 @@ func (c Client) findRelease(version string) (string, error) {
 	}
 
 	var latestValid *semver.Version
-	for name, _ := range targets {
+	for name := range targets {
 		if !strings.HasPrefix(name, releasesDir+"/") {
 			continue
 		}

--- a/client/pkg/repo/use.go
+++ b/client/pkg/repo/use.go
@@ -77,7 +77,7 @@ func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename
 	commonArgsString := strings.Join(commonArgs, " ")
 	foregroundUpdateArgsString := strings.Join(foregroundUpdateArgs, " ")
 	backgroundUpdateArgsString := strings.Join(backgroundUpdateArgs, " ")
-	_ = logPathBackgroundUpdateStderr
+
 	trdlBinaryPath, err := trdl.GetTrdlBinaryPath()
 	if err != nil {
 		return "", nil, err

--- a/client/pkg/repo/use.go
+++ b/client/pkg/repo/use.go
@@ -2,6 +2,8 @@ package repo
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -42,7 +44,7 @@ func (c Client) UseReleaseBinDir(version, shell string, opts UseSourceOptions) (
 	}
 
 	envs := []sourceScriptEnv{
-		{Name: FormatRepoVersionEnvName(c.repoName), Value: resolvedVersion},
+		{Name: FormatRepoVersionEnvName(c.repoName), Value: resolvedVersion, Expression: true},
 		{Name: FormatRepoVersionConstraintEnvName(c.repoName), Value: version},
 	}
 
@@ -65,6 +67,8 @@ type UseSourceOptions struct {
 type sourceScriptEnv struct {
 	Name  string
 	Value string
+	// Expression marks Value as a shell expression (e.g. a command substitution)
+	Expression bool
 }
 
 func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename, shell string, envs []sourceScriptEnv, opts UseSourceOptions) (string, []byte, error) {
@@ -164,9 +168,21 @@ func formatSourceScriptEnvExports(shell string, envs []sourceScriptEnv) string {
 	for _, env := range envs {
 		switch shell {
 		case "pwsh":
-			lines = append(lines, fmt.Sprintf("[System.Environment]::SetEnvironmentVariable('%s',\"%s\",[System.EnvironmentVariableTarget]::Process);", env.Name, env.Value))
+			var value string
+			if env.Expression {
+				value = fmt.Sprintf(`"%s"`, env.Value)
+			} else {
+				value = fmt.Sprintf(`'%s'`, strings.ReplaceAll(env.Value, "'", "''"))
+			}
+			lines = append(lines, fmt.Sprintf("[System.Environment]::SetEnvironmentVariable('%s',%s,[System.EnvironmentVariableTarget]::Process);", env.Name, value))
 		default:
-			lines = append(lines, fmt.Sprintf("export %s=\"%s\"", env.Name, env.Value))
+			var value string
+			if env.Expression {
+				value = fmt.Sprintf(`"%s"`, env.Value)
+			} else {
+				value = fmt.Sprintf(`'%s'`, strings.ReplaceAll(env.Value, "'", `'\''`))
+			}
+			lines = append(lines, fmt.Sprintf("export %s=%s", env.Name, value))
 		}
 	}
 
@@ -248,18 +264,8 @@ func formatRepoName(repoName string) string {
 	return strings.ToUpper(formattedName)
 }
 
-// slugifyConstraint replaces semver constraint symbols by strings for file paths
+// slugifyConstraint returns a filesystem-safe key for the version constraint.
 func slugifyConstraint(constraint string) string {
-	replacer := strings.NewReplacer(
-		">=", "gte_",
-		"<=", "lte_",
-		">", "gt_",
-		"<", "lt_",
-		"^", "caret_",
-		"~", "tilde_",
-		"=", "eq_",
-		" ", "",
-	)
-
-	return replacer.Replace(constraint)
+	sum := sha256.Sum256([]byte(constraint))
+	return hex.EncodeToString(sum[:])[:16]
 }

--- a/client/pkg/repo/use.go
+++ b/client/pkg/repo/use.go
@@ -16,10 +16,11 @@ import (
 func (c Client) UseChannelReleaseBinDir(group, channel, shell string, opts UseSourceOptions) (string, error) {
 	commonArgs := []string{c.repoName, group, channel}
 	basename := c.prepareSourceScriptBasename(fmt.Sprintf("%s_%s", group, channel), shell, opts)
-	envName := FormatRepoChannelGroupEnvName(c.repoName)
-	envValue := fmt.Sprintf("%s %s", group, channel)
+	envs := []sourceScriptEnv{
+		{Name: FormatRepoChannelGroupEnvName(c.repoName), Value: fmt.Sprintf("%s %s", group, channel)},
+	}
 
-	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envName, envValue, opts)
+	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envs, opts)
 	if err != nil {
 		return "", err
 	}
@@ -34,14 +35,18 @@ func (c Client) UseChannelReleaseBinDir(group, channel, shell string, opts UseSo
 func (c Client) UseReleaseBinDir(version, shell string, opts UseSourceOptions) (string, error) {
 	commonArgs := []string{c.repoName, fmt.Sprintf("'%s'", version)}
 	basename := c.prepareSourceScriptBasename(slugifyConstraint(version), shell, opts)
-	envName := FormatRepoVersionEnvName(c.repoName)
 
-	envValue, err := c.prepareVersionExtractor(shell, version)
+	resolvedVersion, err := c.prepareVersionExtractor(shell, version)
 	if err != nil {
 		return "", fmt.Errorf("prepare version extractor: %w", err)
 	}
 
-	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envName, envValue, opts)
+	envs := []sourceScriptEnv{
+		{Name: FormatRepoVersionEnvName(c.repoName), Value: resolvedVersion},
+		{Name: FormatRepoVersionConstraintEnvName(c.repoName), Value: version},
+	}
+
+	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envs, opts)
 	if err != nil {
 		return "", err
 	}
@@ -57,7 +62,12 @@ type UseSourceOptions struct {
 	NoSelfUpdate bool
 }
 
-func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename, shell, trdlUseRepoEnvName, trdlUseRepoEnvValue string, opts UseSourceOptions) (string, []byte, error) {
+type sourceScriptEnv struct {
+	Name  string
+	Value string
+}
+
+func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename, shell string, envs []sourceScriptEnv, opts UseSourceOptions) (string, []byte, error) {
 	logPathBackgroundUpdateStdout := filepath.Join(c.logsDir, basename+"_background_update_stdout.log")
 	logPathBackgroundUpdateStderr := filepath.Join(c.logsDir, basename+"_background_update_stderr.log")
 
@@ -104,8 +114,7 @@ if ((Invoke-Expression -Command "%[5]s bin-path %[1]s" 2> $null | Out-String -Ou
    $trdlRepoBinPath = %[5]s bin-path %[1]s
 }
 
-[System.Environment]::SetEnvironmentVariable('%[6]s',"%[7]s",[System.EnvironmentVariableTarget]::Process);
-
+%[6]s
 $trdlRepoBinPath = $trdlRepoBinPath.Trim()
 $oldPath = [System.Environment]::GetEnvironmentVariable('PATH',[System.EnvironmentVariableTarget]::Process)
 $newPath = "$trdlRepoBinPath;$oldPath"
@@ -126,20 +135,18 @@ else
    trdl_repo_bin_path="$(%[5]q bin-path %[1]s)"
 fi
 
-export %[6]s="%[7]s"
-
+%[6]s
 export PATH="$trdl_repo_bin_path${PATH:+:${PATH}}"
 `
 	}
 
 	script := fmt.Sprintf(tmpl,
-		commonArgsString,              // %[1]s: REPO GROUP CHANNEL            (common args string)
-		foregroundUpdateArgsString,    // %[2]s: REPO GROUP CHANNEL [flag ...] (foreground update args string)
-		backgroundUpdateArgsString,    // %[3]s: REPO GROUP CHANNEL [flag ...] (background update args string)
-		logPathBackgroundUpdateStderr, // %[4]s: <path>                        (background update error file path)
-		trdlBinaryPath,                // %[5]s: <path>                        (trdl binary path)
-		trdlUseRepoEnvName,            // %[6]s: <env name>                    (TRDL_USE_<REPO>_GROUP_CHANNEL)
-		trdlUseRepoEnvValue,           // %[7]s: <env value>                   (TRDL_USE_<REPO>_GROUP_CHANNEL value)
+		commonArgsString,                          // %[1]s: REPO GROUP CHANNEL            (common args string)
+		foregroundUpdateArgsString,                // %[2]s: REPO GROUP CHANNEL [flag ...] (foreground update args string)
+		backgroundUpdateArgsString,                // %[3]s: REPO GROUP CHANNEL [flag ...] (background update args string)
+		logPathBackgroundUpdateStderr,             // %[4]s: <path>                        (background update error file path)
+		trdlBinaryPath,                            // %[5]s: <path>                        (trdl binary path)
+		formatSourceScriptEnvExports(shell, envs), // %[6]s: <env exports block>
 	)
 
 	name := "source_script"
@@ -150,6 +157,20 @@ export PATH="$trdl_repo_bin_path${PATH:+:${PATH}}"
 	data := []byte(fmt.Sprintln(strings.TrimSpace(script)))
 
 	return name, data, nil
+}
+
+func formatSourceScriptEnvExports(shell string, envs []sourceScriptEnv) string {
+	lines := make([]string, 0, len(envs))
+	for _, env := range envs {
+		switch shell {
+		case "pwsh":
+			lines = append(lines, fmt.Sprintf("[System.Environment]::SetEnvironmentVariable('%s',\"%s\",[System.EnvironmentVariableTarget]::Process);", env.Name, env.Value))
+		default:
+			lines = append(lines, fmt.Sprintf("export %s=\"%s\"", env.Name, env.Value))
+		}
+	}
+
+	return strings.Join(lines, "\n")
 }
 
 func (c Client) prepareSourceScriptBasename(selector, shell string, opts UseSourceOptions) string {
@@ -208,8 +229,15 @@ func FormatRepoChannelGroupEnvName(repoName string) string {
 }
 
 // FormatRepoVersionEnvName returns a formatted repo version env name
+// It carries the resolved release name (e.g. "v0.0.2").
 func FormatRepoVersionEnvName(repoName string) string {
 	return fmt.Sprintf("TRDL_USE_%s_VERSION", formatRepoName(repoName))
+}
+
+// FormatRepoVersionConstraintEnvName returns a formatted repo version constraint env name.
+// It carries the original version selector requested by the user (e.g. ">=0.0.1").
+func FormatRepoVersionConstraintEnvName(repoName string) string {
+	return fmt.Sprintf("TRDL_USE_%s_VERSION_CONSTRAINT", formatRepoName(repoName))
 }
 
 // formatRepoName returns a formatted repository name.

--- a/client/pkg/repo/use.go
+++ b/client/pkg/repo/use.go
@@ -16,7 +16,10 @@ import (
 func (c Client) UseChannelReleaseBinDir(group, channel, shell string, opts UseSourceOptions) (string, error) {
 	commonArgs := []string{c.repoName, group, channel}
 	basename := c.prepareSourceScriptBasename(fmt.Sprintf("%s_%s", group, channel), shell, opts)
-	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, group, channel, opts)
+	envName := FormatRepoChannelGroupEnvName(c.repoName)
+	envValue := fmt.Sprintf("%s %s", group, channel)
+
+	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envName, envValue, opts)
 	if err != nil {
 		return "", err
 	}
@@ -29,9 +32,11 @@ func (c Client) UseChannelReleaseBinDir(group, channel, shell string, opts UseSo
 }
 
 func (c Client) UseReleaseBinDir(version, shell string, opts UseSourceOptions) (string, error) {
-	commonArgs := []string{c.repoName, fmt.Sprintf("--version=%s", version)}
-	basename := c.prepareSourceScriptBasename(fmt.Sprintf("version_%s", version), shell, opts)
-	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, version, "", opts)
+	commonArgs := []string{c.repoName, fmt.Sprintf("v%s", version)}
+	basename := c.prepareSourceScriptBasename(fmt.Sprintf("v%s", version), shell, opts)
+	envName := FormatRepoVersionEnvName(c.repoName)
+
+	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envName, version, opts)
 	if err != nil {
 		return "", err
 	}
@@ -47,7 +52,7 @@ type UseSourceOptions struct {
 	NoSelfUpdate bool
 }
 
-func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename, shell, envValuePrimary, envValueSecondary string, opts UseSourceOptions) (string, []byte, error) {
+func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename, shell, trdlUseRepoEnvName, trdlUseRepoEnvValue string, opts UseSourceOptions) (string, []byte, error) {
 	logPathBackgroundUpdateStdout := filepath.Join(c.logsDir, basename+"_background_update_stdout.log")
 	logPathBackgroundUpdateStderr := filepath.Join(c.logsDir, basename+"_background_update_stderr.log")
 
@@ -71,13 +76,6 @@ func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename
 	trdlBinaryPath, err := trdl.GetTrdlBinaryPath()
 	if err != nil {
 		return "", nil, err
-	}
-	trdlUseRepoGroupChannelEnvName := FormatRepoChannelGroupEnvName(c.repoName)
-	var trdlUseRepoGroupChannelEnvValue string
-	if envValueSecondary != "" {
-		trdlUseRepoGroupChannelEnvValue = fmt.Sprintf("%s %s", envValuePrimary, envValueSecondary)
-	} else {
-		trdlUseRepoGroupChannelEnvValue = envValuePrimary
 	}
 
 	var tmpl string
@@ -130,13 +128,13 @@ export PATH="$trdl_repo_bin_path${PATH:+:${PATH}}"
 	}
 
 	script := fmt.Sprintf(tmpl,
-		commonArgsString,                // %[1]s: REPO GROUP CHANNEL            (common args string)
-		foregroundUpdateArgsString,      // %[2]s: REPO GROUP CHANNEL [flag ...] (foreground update args string)
-		backgroundUpdateArgsString,      // %[3]s: REPO GROUP CHANNEL [flag ...] (background update args string)
-		logPathBackgroundUpdateStderr,   // %[4]s: <path>                        (background update error file path)
-		trdlBinaryPath,                  // %[5]s: <path>                        (trdl binary path)
-		trdlUseRepoGroupChannelEnvName,  // %[6]s: <env name>                    (TRDL_USE_<REPO>_GROUP_CHANNEL)
-		trdlUseRepoGroupChannelEnvValue, // %[7]s: <env value>                   (TRDL_USE_<REPO>_GROUP_CHANNEL value)
+		commonArgsString,              // %[1]s: REPO GROUP CHANNEL            (common args string)
+		foregroundUpdateArgsString,    // %[2]s: REPO GROUP CHANNEL [flag ...] (foreground update args string)
+		backgroundUpdateArgsString,    // %[3]s: REPO GROUP CHANNEL [flag ...] (background update args string)
+		logPathBackgroundUpdateStderr, // %[4]s: <path>                        (background update error file path)
+		trdlBinaryPath,                // %[5]s: <path>                        (trdl binary path)
+		trdlUseRepoEnvName,            // %[6]s: <env name>                    (TRDL_USE_<REPO>_GROUP_CHANNEL)
+		trdlUseRepoEnvValue,           // %[7]s: <env value>                   (TRDL_USE_<REPO>_GROUP_CHANNEL value)
 	)
 
 	name := "source_script"
@@ -188,6 +186,11 @@ func (c Client) syncSourceScriptFile(scriptsDir, scriptsTmpDir, name string, dat
 // FormatRepoChannelGroupEnvName returns a formatted repo channel group env name
 func FormatRepoChannelGroupEnvName(repoName string) string {
 	return fmt.Sprintf("TRDL_USE_%s_GROUP_CHANNEL", formatRepoName(repoName))
+}
+
+// FormatRepoVersionEnvName returns a formatted repo version env name
+func FormatRepoVersionEnvName(repoName string) string {
+	return fmt.Sprintf("TRDL_USE_%s_VERSION", formatRepoName(repoName))
 }
 
 // formatRepoName returns a formatted repository name.

--- a/client/pkg/repo/use.go
+++ b/client/pkg/repo/use.go
@@ -32,11 +32,16 @@ func (c Client) UseChannelReleaseBinDir(group, channel, shell string, opts UseSo
 }
 
 func (c Client) UseReleaseBinDir(version, shell string, opts UseSourceOptions) (string, error) {
-	commonArgs := []string{c.repoName, fmt.Sprintf("v%s", version)}
-	basename := c.prepareSourceScriptBasename(fmt.Sprintf("v%s", version), shell, opts)
+	commonArgs := []string{c.repoName, fmt.Sprintf("'%s'", version)}
+	basename := c.prepareSourceScriptBasename(slugifyConstraint(version), shell, opts)
 	envName := FormatRepoVersionEnvName(c.repoName)
 
-	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envName, version, opts)
+	envValue, err := c.prepareVersionExtractor(shell, version)
+	if err != nil {
+		return "", fmt.Errorf("prepare version extractor: %w", err)
+	}
+
+	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envName, envValue, opts)
 	if err != nil {
 		return "", err
 	}
@@ -99,7 +104,7 @@ if ((Invoke-Expression -Command "%[5]s bin-path %[1]s" 2> $null | Out-String -Ou
    $trdlRepoBinPath = %[5]s bin-path %[1]s
 }
 
-[System.Environment]::SetEnvironmentVariable('%[6]s','%[7]s',[System.EnvironmentVariableTarget]::Process);
+[System.Environment]::SetEnvironmentVariable('%[6]s',"%[7]s",[System.EnvironmentVariableTarget]::Process);
 
 $trdlRepoBinPath = $trdlRepoBinPath.Trim()
 $oldPath = [System.Environment]::GetEnvironmentVariable('PATH',[System.EnvironmentVariableTarget]::Process)
@@ -183,6 +188,20 @@ func (c Client) syncSourceScriptFile(scriptsDir, scriptsTmpDir, name string, dat
 	return scriptPath, nil
 }
 
+func (c Client) prepareVersionExtractor(shell, version string) (string, error) {
+	trdlBinaryPath, err := trdl.GetTrdlBinaryPath()
+	if err != nil {
+		return "", err
+	}
+
+	switch shell {
+	case "pwsh":
+		return fmt.Sprintf("$(((%s dir-path %s '%s') -split '[\\\\/]')[-2])", trdlBinaryPath, c.repoName, version), nil
+	default:
+		return fmt.Sprintf("$(%q dir-path %s '%s' | awk -F'/' '{print $(NF-1)}')", trdlBinaryPath, c.repoName, version), nil
+	}
+}
+
 // FormatRepoChannelGroupEnvName returns a formatted repo channel group env name
 func FormatRepoChannelGroupEnvName(repoName string) string {
 	return fmt.Sprintf("TRDL_USE_%s_GROUP_CHANNEL", formatRepoName(repoName))
@@ -199,4 +218,20 @@ func formatRepoName(repoName string) string {
 	re := regexp.MustCompile("[^a-zA-Z0-9_]+")
 	formattedName := re.ReplaceAllString(repoName, "_")
 	return strings.ToUpper(formattedName)
+}
+
+// slugifyConstraint replaces semver constraint symbols by strings for file paths
+func slugifyConstraint(constraint string) string {
+	replacer := strings.NewReplacer(
+		">=", "gte_",
+		"<=", "lte_",
+		">", "gt_",
+		"<", "lt_",
+		"^", "caret_",
+		"~", "tilde_",
+		"=", "eq_",
+		" ", "",
+	)
+
+	return replacer.Replace(constraint)
 }

--- a/client/pkg/repo/use.go
+++ b/client/pkg/repo/use.go
@@ -14,11 +14,28 @@ import (
 )
 
 func (c Client) UseChannelReleaseBinDir(group, channel, shell string, opts UseSourceOptions) (string, error) {
-	name, data, err := c.prepareSourceScriptFileNameAndData(group, channel, shell, opts)
+	commonArgs := []string{c.repoName, group, channel}
+	basename := c.prepareSourceScriptBasename(fmt.Sprintf("%s_%s", group, channel), shell, opts)
+	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, group, channel, opts)
 	if err != nil {
 		return "", err
 	}
-	sourceScriptPath, err := c.syncSourceScriptFile(group, channel, name, data)
+	sourceScriptPath, err := c.syncSourceScriptFile(c.channelScriptsDir(group, channel), c.channelScriptsTmpDir(group, channel), name, data)
+	if err != nil {
+		return "", err
+	}
+
+	return sourceScriptPath, nil
+}
+
+func (c Client) UseReleaseBinDir(version, shell string, opts UseSourceOptions) (string, error) {
+	commonArgs := []string{c.repoName, fmt.Sprintf("--version=%s", version)}
+	basename := c.prepareSourceScriptBasename(fmt.Sprintf("version_%s", version), shell, opts)
+	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, version, "", opts)
+	if err != nil {
+		return "", err
+	}
+	sourceScriptPath, err := c.syncSourceScriptFile(c.versionScriptsDir(version), c.versionScriptsTmpDir(version), name, data)
 	if err != nil {
 		return "", err
 	}
@@ -30,12 +47,10 @@ type UseSourceOptions struct {
 	NoSelfUpdate bool
 }
 
-func (c Client) prepareSourceScriptFileNameAndData(group, channel, shell string, opts UseSourceOptions) (string, []byte, error) {
-	basename := c.prepareSourceScriptBasename(group, channel, shell, opts)
+func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename, shell, envValuePrimary, envValueSecondary string, opts UseSourceOptions) (string, []byte, error) {
 	logPathBackgroundUpdateStdout := filepath.Join(c.logsDir, basename+"_background_update_stdout.log")
 	logPathBackgroundUpdateStderr := filepath.Join(c.logsDir, basename+"_background_update_stderr.log")
 
-	commonArgs := []string{c.repoName, group, channel}
 	foregroundUpdateArgs := commonArgs[0:]
 	backgroundUpdateArgs := append(
 		append([]string{}, commonArgs[0:]...),
@@ -58,7 +73,12 @@ func (c Client) prepareSourceScriptFileNameAndData(group, channel, shell string,
 		return "", nil, err
 	}
 	trdlUseRepoGroupChannelEnvName := FormatRepoChannelGroupEnvName(c.repoName)
-	trdlUseRepoGroupChannelEnvValue := fmt.Sprintf("%s %s", group, channel)
+	var trdlUseRepoGroupChannelEnvValue string
+	if envValueSecondary != "" {
+		trdlUseRepoGroupChannelEnvValue = fmt.Sprintf("%s %s", envValuePrimary, envValueSecondary)
+	} else {
+		trdlUseRepoGroupChannelEnvValue = envValuePrimary
+	}
 
 	var tmpl string
 	var ext string
@@ -129,8 +149,8 @@ export PATH="$trdl_repo_bin_path${PATH:+:${PATH}}"
 	return name, data, nil
 }
 
-func (c Client) prepareSourceScriptBasename(group, channel, shell string, opts UseSourceOptions) string {
-	basename := fmt.Sprintf("use_%s_%s_%s", group, channel, shell)
+func (c Client) prepareSourceScriptBasename(selector, shell string, opts UseSourceOptions) string {
+	basename := fmt.Sprintf("use_%s_%s", selector, shell)
 
 	if opts.NoSelfUpdate {
 		basename += "_" + util.MurmurHash(fmt.Sprintf("%+v", opts))
@@ -139,8 +159,8 @@ func (c Client) prepareSourceScriptBasename(group, channel, shell string, opts U
 	return basename
 }
 
-func (c Client) syncSourceScriptFile(group, channel, name string, data []byte) (string, error) {
-	scriptPath := filepath.Join(c.channelScriptsDir(group, channel), name)
+func (c Client) syncSourceScriptFile(scriptsDir, scriptsTmpDir, name string, data []byte) (string, error) {
+	scriptPath := filepath.Join(scriptsDir, name)
 
 	exist, err := util.IsRegularFileExist(scriptPath)
 	if err != nil {
@@ -158,7 +178,7 @@ func (c Client) syncSourceScriptFile(group, channel, name string, data []byte) (
 		}
 	}
 
-	if err := util.AtomicWriteFile(scriptPath, data, os.ModePerm, c.channelScriptsTmpDir(group, channel)); err != nil {
+	if err := util.AtomicWriteFile(scriptPath, data, os.ModePerm, scriptsTmpDir); err != nil {
 		return "", fmt.Errorf("write source script %q: %w", scriptPath, err)
 	}
 

--- a/client/pkg/repo/use.go
+++ b/client/pkg/repo/use.go
@@ -20,6 +20,8 @@ func (c Client) UseChannelReleaseBinDir(group, channel, shell string, opts UseSo
 	basename := c.prepareSourceScriptBasename(fmt.Sprintf("%s_%s", group, channel), shell, opts)
 	envs := []sourceScriptEnv{
 		{Name: FormatRepoChannelGroupEnvName(c.repoName), Value: fmt.Sprintf("%s %s", group, channel)},
+		{Name: FormatRepoVersionEnvName(c.repoName), Unset: true},
+		{Name: FormatRepoVersionConstraintEnvName(c.repoName), Unset: true},
 	}
 
 	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envs, opts)
@@ -46,6 +48,7 @@ func (c Client) UseReleaseBinDir(version, shell string, opts UseSourceOptions) (
 	envs := []sourceScriptEnv{
 		{Name: FormatRepoVersionEnvName(c.repoName), Value: resolvedVersion, Expression: true},
 		{Name: FormatRepoVersionConstraintEnvName(c.repoName), Value: version},
+		{Name: FormatRepoChannelGroupEnvName(c.repoName), Unset: true},
 	}
 
 	name, data, err := c.prepareSourceScriptFileNameAndData(commonArgs, basename, shell, envs, opts)
@@ -69,6 +72,9 @@ type sourceScriptEnv struct {
 	Value string
 	// Expression marks Value as a shell expression (e.g. a command substitution)
 	Expression bool
+	// Unset removes the variable instead of setting it, clearing stale values
+	// left by a previous use of the opposite selection mode.
+	Unset bool
 }
 
 func (c Client) prepareSourceScriptFileNameAndData(commonArgs []string, basename, shell string, envs []sourceScriptEnv, opts UseSourceOptions) (string, []byte, error) {
@@ -168,6 +174,10 @@ func formatSourceScriptEnvExports(shell string, envs []sourceScriptEnv) string {
 	for _, env := range envs {
 		switch shell {
 		case "pwsh":
+			if env.Unset {
+				lines = append(lines, fmt.Sprintf("[System.Environment]::SetEnvironmentVariable('%s',$null,[System.EnvironmentVariableTarget]::Process);", env.Name))
+				continue
+			}
 			var value string
 			if env.Expression {
 				value = fmt.Sprintf(`"%s"`, env.Value)
@@ -176,6 +186,10 @@ func formatSourceScriptEnvExports(shell string, envs []sourceScriptEnv) string {
 			}
 			lines = append(lines, fmt.Sprintf("[System.Environment]::SetEnvironmentVariable('%s',%s,[System.EnvironmentVariableTarget]::Process);", env.Name, value))
 		default:
+			if env.Unset {
+				lines = append(lines, fmt.Sprintf("unset %s", env.Name))
+				continue
+			}
 			var value string
 			if env.Expression {
 				value = fmt.Sprintf(`"%s"`, env.Value)

--- a/client/pkg/repo/use_ai_test.go
+++ b/client/pkg/repo/use_ai_test.go
@@ -1,0 +1,89 @@
+//go:build ai_tests
+
+package repo
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestAI_formatSourceScriptEnvExports_pwshLiteralEscaping(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "dollar not expanded", value: "a$b", want: `'a$b'`},
+		{name: "single quote doubled", value: "x'y", want: `'x''y'`},
+		{name: "command substitution inert", value: "$(rm -rf /)", want: `'$(rm -rf /)'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := formatSourceScriptEnvExports("pwsh", []sourceScriptEnv{{Name: "NAME", Value: tt.value}})
+			if !strings.Contains(out, tt.want) {
+				t.Fatalf("pwsh literal %q: got %q, want substring %q", tt.value, out, tt.want)
+			}
+		})
+	}
+}
+
+func TestAI_formatSourceScriptEnvExports_pwshExpression(t *testing.T) {
+	out := formatSourceScriptEnvExports("pwsh", []sourceScriptEnv{{Name: "NAME", Value: "$(cmd)", Expression: true}})
+	if !strings.Contains(out, `"$(cmd)"`) {
+		t.Fatalf("pwsh expression: got %q, want double-quoted expression", out)
+	}
+}
+
+func TestAI_formatSourceScriptEnvExports_unixLiteralEscaping(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "dollar not expanded", value: "a$b", want: `export NAME='a$b'`},
+		{name: "single quote escaped", value: "x'y", want: `export NAME='x'\''y'`},
+		{name: "command substitution inert", value: "$(rm -rf /)", want: `export NAME='$(rm -rf /)'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := formatSourceScriptEnvExports("unix", []sourceScriptEnv{{Name: "NAME", Value: tt.value}})
+			if !strings.Contains(out, tt.want) {
+				t.Fatalf("unix literal %q: got %q, want substring %q", tt.value, out, tt.want)
+			}
+		})
+	}
+}
+
+func TestAI_formatSourceScriptEnvExports_unixExpression(t *testing.T) {
+	out := formatSourceScriptEnvExports("unix", []sourceScriptEnv{{Name: "NAME", Value: "$(cmd)", Expression: true}})
+	if !strings.Contains(out, `export NAME="$(cmd)"`) {
+		t.Fatalf("unix expression: got %q, want double-quoted expression", out)
+	}
+}
+
+var slugKeyRegexp = regexp.MustCompile(`^[0-9a-f]{16}$`)
+
+func TestAI_slugifyConstraint(t *testing.T) {
+	inputs := []string{">=1.0 || <2.0", "1.2.*", "!=1.2.3", "1.2 - 1.4"}
+
+	seen := make(map[string]string, len(inputs))
+	for _, in := range inputs {
+		got := slugifyConstraint(in)
+
+		if !slugKeyRegexp.MatchString(got) {
+			t.Fatalf("slugifyConstraint(%q) = %q, want match %s", in, got, slugKeyRegexp)
+		}
+
+		if again := slugifyConstraint(in); again != got {
+			t.Fatalf("slugifyConstraint(%q) not deterministic: %q != %q", in, got, again)
+		}
+
+		if prev, ok := seen[got]; ok {
+			t.Fatalf("slug collision: %q and %q both map to %q", prev, in, got)
+		}
+		seen[got] = in
+	}
+}

--- a/client/pkg/repo/use_test.go
+++ b/client/pkg/repo/use_test.go
@@ -34,6 +34,13 @@ func TestFormatSourceScriptEnvExports_pwshExpression(t *testing.T) {
 	}
 }
 
+func TestFormatSourceScriptEnvExports_pwshUnset(t *testing.T) {
+	out := formatSourceScriptEnvExports("pwsh", []sourceScriptEnv{{Name: "NAME", Unset: true}})
+	if !strings.Contains(out, `[System.Environment]::SetEnvironmentVariable('NAME',$null,[System.EnvironmentVariableTarget]::Process);`) {
+		t.Fatalf("pwsh unset: got %q, want SetEnvironmentVariable with $null", out)
+	}
+}
+
 func TestFormatSourceScriptEnvExports_unixLiteralEscaping(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -52,6 +59,13 @@ func TestFormatSourceScriptEnvExports_unixLiteralEscaping(t *testing.T) {
 				t.Fatalf("unix literal %q: got %q, want substring %q", tt.value, out, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatSourceScriptEnvExports_unixUnset(t *testing.T) {
+	out := formatSourceScriptEnvExports("unix", []sourceScriptEnv{{Name: "NAME", Unset: true}})
+	if !strings.Contains(out, "unset NAME") {
+		t.Fatalf("unix unset: got %q, want \"unset NAME\"", out)
 	}
 }
 

--- a/client/pkg/repo/use_test.go
+++ b/client/pkg/repo/use_test.go
@@ -1,5 +1,3 @@
-//go:build ai_tests
-
 package repo
 
 import (
@@ -8,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestAI_formatSourceScriptEnvExports_pwshLiteralEscaping(t *testing.T) {
+func TestFormatSourceScriptEnvExports_pwshLiteralEscaping(t *testing.T) {
 	tests := []struct {
 		name  string
 		value string
@@ -29,14 +27,14 @@ func TestAI_formatSourceScriptEnvExports_pwshLiteralEscaping(t *testing.T) {
 	}
 }
 
-func TestAI_formatSourceScriptEnvExports_pwshExpression(t *testing.T) {
+func TestFormatSourceScriptEnvExports_pwshExpression(t *testing.T) {
 	out := formatSourceScriptEnvExports("pwsh", []sourceScriptEnv{{Name: "NAME", Value: "$(cmd)", Expression: true}})
 	if !strings.Contains(out, `"$(cmd)"`) {
 		t.Fatalf("pwsh expression: got %q, want double-quoted expression", out)
 	}
 }
 
-func TestAI_formatSourceScriptEnvExports_unixLiteralEscaping(t *testing.T) {
+func TestFormatSourceScriptEnvExports_unixLiteralEscaping(t *testing.T) {
 	tests := []struct {
 		name  string
 		value string
@@ -57,7 +55,7 @@ func TestAI_formatSourceScriptEnvExports_unixLiteralEscaping(t *testing.T) {
 	}
 }
 
-func TestAI_formatSourceScriptEnvExports_unixExpression(t *testing.T) {
+func TestFormatSourceScriptEnvExports_unixExpression(t *testing.T) {
 	out := formatSourceScriptEnvExports("unix", []sourceScriptEnv{{Name: "NAME", Value: "$(cmd)", Expression: true}})
 	if !strings.Contains(out, `export NAME="$(cmd)"`) {
 		t.Fatalf("unix expression: got %q, want double-quoted expression", out)
@@ -66,7 +64,7 @@ func TestAI_formatSourceScriptEnvExports_unixExpression(t *testing.T) {
 
 var slugKeyRegexp = regexp.MustCompile(`^[0-9a-f]{16}$`)
 
-func TestAI_slugifyConstraint(t *testing.T) {
+func TestSlugifyConstraint(t *testing.T) {
 	inputs := []string{">=1.0 || <2.0", "1.2.*", "!=1.2.3", "1.2 - 1.4"}
 
 	seen := make(map[string]string, len(inputs))

--- a/client/pkg/util/metafile.go
+++ b/client/pkg/util/metafile.go
@@ -90,7 +90,7 @@ func (f Metafile) delete() error {
 }
 
 func (f Metafile) Exists(locker lockgate.Locker) (exists bool, err error) {
-	err = lockgate.WithAcquire(locker, f.filePath, lockgate.AcquireOptions{Shared: false, Timeout: metafileLockTimeout}, func(_ bool) error {
+	err = lockgate.WithAcquire(locker, f.filePath, lockgate.AcquireOptions{Shared: true, Timeout: metafileLockTimeout}, func(_ bool) error {
 		exists, err = IsRegularFileExist(f.filePath)
 
 		return err

--- a/client/pkg/util/metafile.go
+++ b/client/pkg/util/metafile.go
@@ -88,3 +88,13 @@ func (f Metafile) delete() error {
 
 	return nil
 }
+
+func (f Metafile) Exists(locker lockgate.Locker) (exists bool, err error) {
+	err = lockgate.WithAcquire(locker, f.filePath, lockgate.AcquireOptions{Shared: false, Timeout: metafileLockTimeout}, func(_ bool) error {
+		exists, err = IsRegularFileExist(f.filePath)
+
+		return err
+	})
+
+	return
+}

--- a/docs/_includes/reference/cli/trdl_bin_path.md
+++ b/docs/_includes/reference/cli/trdl_bin_path.md
@@ -3,7 +3,7 @@ Get the directory with software binaries
 ## Syntax
 
 ```shell
-trdl bin-path REPO GROUP [CHANNEL]
+trdl bin-path REPO GROUP [CHANNEL] | REPO VERSION
 ```
 
 ## Options inherited from parent commands

--- a/docs/_includes/reference/cli/trdl_dir_path.md
+++ b/docs/_includes/reference/cli/trdl_dir_path.md
@@ -3,7 +3,7 @@ Get the directory with software artifacts
 ## Syntax
 
 ```shell
-trdl dir-path REPO GROUP [CHANNEL]
+trdl dir-path REPO GROUP [CHANNEL] | REPO VERSION
 ```
 
 ## Options inherited from parent commands

--- a/docs/_includes/reference/cli/trdl_exec.md
+++ b/docs/_includes/reference/cli/trdl_exec.md
@@ -3,7 +3,7 @@ Exec a software binary
 ## Syntax
 
 ```shell
-trdl exec REPO GROUP [CHANNEL] [BINARY_NAME] [--] [ARGS]
+trdl exec REPO GROUP [CHANNEL] [BINARY_NAME] [--] [ARGS] | REPO VERSION [BINARY_NAME] [--] [ARGS]
 ```
 
 ## Options inherited from parent commands

--- a/docs/_includes/reference/cli/trdl_update.md
+++ b/docs/_includes/reference/cli/trdl_update.md
@@ -6,6 +6,12 @@ Update the software
 trdl update REPO GROUP [CHANNEL] | REPO VERSION [options]
 ```
 
+## Aliases
+
+```shell
+update, download
+```
+
 ## Options
 
 ```shell

--- a/docs/_includes/reference/cli/trdl_update.md
+++ b/docs/_includes/reference/cli/trdl_update.md
@@ -3,7 +3,7 @@ Update the software
 ## Syntax
 
 ```shell
-trdl update REPO GROUP [CHANNEL] [options]
+trdl update REPO GROUP [CHANNEL] | REPO VERSION [options]
 ```
 
 ## Options

--- a/docs/_includes/reference/cli/trdl_use.md
+++ b/docs/_includes/reference/cli/trdl_use.md
@@ -3,7 +3,7 @@ Generate a script to update the software binaries in the background and use loca
 ## Syntax
 
 ```shell
-trdl use REPO GROUP [CHANNEL] [options]
+trdl use REPO GROUP [CHANNEL] | REPO VERSION [options]
 ```
 
 ## Examples
@@ -11,6 +11,9 @@ trdl use REPO GROUP [CHANNEL] [options]
 ```shell
   # Source script in a shell
   $ . $(trdl use repo_name 1.2 ea)
+
+  # Pin an explicit version instead of a group/channel
+  $ . $(trdl use repo_name v1.2.3)
 
   # Force script generation for a Unix shell on Windows
   $ trdl use repo_name 1.2 ea --shell unix

--- a/docs/_includes/reference/cli/trdl_use.md
+++ b/docs/_includes/reference/cli/trdl_use.md
@@ -13,7 +13,11 @@ trdl use REPO GROUP [CHANNEL] | REPO VERSION [options]
   $ . $(trdl use repo_name 1.2 ea)
 
   # Pin an explicit version instead of a group/channel
+  # (an exact version must be prefixed with "v", otherwise it is treated as a group)
   $ . $(trdl use repo_name v1.2.3)
+
+  # Pin a semver constraint (resolves to the greatest matching release)
+  $ . $(trdl use repo_name '>=1.2.0')
 
   # Force script generation for a Unix shell on Windows
   $ trdl use repo_name 1.2 ea --shell unix

--- a/e2e/tests/client/version_test.go
+++ b/e2e/tests/client/version_test.go
@@ -1,0 +1,149 @@
+package client
+
+import (
+	"path/filepath"
+	"runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/trdl/server/pkg/testutil"
+)
+
+var _ = Describe("Version pinning", func() {
+	When("repo added", func() {
+		BeforeEach(func() {
+			testutil.RunSucceedCommand(
+				"",
+				trdlBinPath,
+				"add", "-d", testRepoName, validRepoUrl, validRootVersion, validRootSHA512,
+			)
+		})
+
+		DescribeTable("should update to a version matching the selector",
+			func(selector, expectedRelease string) {
+				testutil.RunSucceedCommand(
+					"",
+					trdlBinPath,
+					"update", testRepoName, selector,
+				)
+
+				output := testutil.SucceedCommandOutputString(
+					"",
+					trdlBinPath,
+					"bin-path", testRepoName, selector,
+				)
+				Expect(output).Should(Equal(releaseBinDir(expectedRelease) + "\n"))
+			},
+			Entry("exact version", "v0.0.1", "v0.0.1"),
+			Entry("exact latest version", "v0.0.2", "v0.0.2"),
+			Entry("range >= resolves to the greatest match", ">=0.0.1", "v0.0.2"),
+			Entry("range < excludes the greatest", "<0.0.2", "v0.0.1"),
+			Entry("tilde constraint", "~0.0.1", "v0.0.2"),
+			Entry("caret constraint", "^0.0.1", "v0.0.1"),
+		)
+
+		When("updated to a pinned version", func() {
+			BeforeEach(func() {
+				testutil.RunSucceedCommand(
+					"",
+					trdlBinPath,
+					"update", testRepoName, "v0.0.1",
+				)
+			})
+
+			It("bin-path", func() {
+				output := testutil.SucceedCommandOutputString(
+					"",
+					trdlBinPath,
+					"bin-path", testRepoName, "v0.0.1",
+				)
+				Expect(output).Should(Equal(releaseBinDir("v0.0.1") + "\n"))
+			})
+
+			It("dir-path", func() {
+				output := testutil.SucceedCommandOutputString(
+					"",
+					trdlBinPath,
+					"dir-path", testRepoName, "v0.0.1",
+				)
+				Expect(output).Should(Equal(releaseDir("v0.0.1") + "\n"))
+			})
+
+			It("exec", func() {
+				args := []string{"exec", testRepoName, "v0.0.1"}
+				if runtime.GOOS == "windows" {
+					args = append(args, "script.bat")
+				}
+
+				output := testutil.SucceedCommandOutputString(
+					"",
+					trdlBinPath,
+					args...,
+				)
+
+				if runtime.GOOS == "windows" {
+					Expect(output).Should(Equal("\"v0.0.1\"\r\n"))
+				} else {
+					Expect(output).Should(Equal("v0.0.1\n"))
+				}
+			})
+		})
+
+		It("should reject an invalid version selector on exec", func() {
+			_, err := testutil.RunCommandWithOptions(
+				"",
+				trdlBinPath,
+				[]string{"exec", testRepoName, "v#bad"},
+				testutil.RunCommandOptions{ShouldSucceed: false},
+			)
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("should fail to exec a version that has not been pinned locally", func() {
+			output, err := testutil.RunCommandWithOptions(
+				"",
+				trdlBinPath,
+				[]string{"exec", testRepoName, "v0.0.2"},
+				testutil.RunCommandOptions{ShouldSucceed: false},
+			)
+			Expect(err).Should(HaveOccurred())
+			Expect(string(output)).Should(ContainSubstring("not found locally"))
+		})
+
+		It("should preserve a pinned version across an autoclean update", func() {
+			testutil.RunSucceedCommand(
+				"",
+				trdlBinPath,
+				"update", testRepoName, "v0.0.1",
+			)
+
+			testutil.RunSucceedCommand(
+				"",
+				trdlBinPath,
+				"update", testRepoName, "v0.0.2", "--autoclean",
+			)
+
+			By("the older pinned version is still resolvable")
+			output := testutil.SucceedCommandOutputString(
+				"",
+				trdlBinPath,
+				"bin-path", testRepoName, "v0.0.1",
+			)
+			Expect(output).Should(Equal(releaseBinDir("v0.0.1") + "\n"))
+		})
+	})
+})
+
+func releaseDir(release string) string {
+	osArch := "any-any"
+	if runtime.GOOS == "windows" {
+		osArch = "windows-any"
+	}
+
+	return filepath.Join(trdlHomeDir, "repositories/test/releases", release, osArch)
+}
+
+func releaseBinDir(release string) string {
+	return filepath.Join(releaseDir(release), "bin")
+}

--- a/server/path_publish.go
+++ b/server/path_publish.go
@@ -235,6 +235,10 @@ func ValidatePublishConfig(ctx context.Context, publisher publisher.Interface, p
 	processedGroups := map[string]bool{}
 
 	for _, group := range config.Groups {
+		if strings.HasPrefix(group.Name, "v") {
+			return fmt.Errorf("bad group name %q, expected semver without \"v\" prefix", group.Name)
+		}
+
 		if _, err := semver.NewVersion(group.Name); err != nil {
 			return fmt.Errorf("expected semver group got %q: %w", group.Name, err)
 		}


### PR DESCRIPTION
## Summary

Add an explicit-VERSION mode to the main `trdl` client commands (`use`, `exec`, `update`, `bin-path`, `dir-path`) so users can pin a raw release (`v1.2.3`) or a semver constraint (`>=1.2.0`, `1.2.*`, `~1.2`) alongside the existing GROUP/CHANNEL selection. Add matching server-side validation to keep the two selection modes unambiguous.

## Key changes

- `client/cmd/trdl/common.go`: introduce `isVersionArg` (strict `v`+digit prefix OR valid semver constraint) and `validateVersionArgs` to dispatch between GROUP/CHANNEL and VERSION modes.
- `client/cmd/trdl/{use,exec,update,bin_path,dir_path}.go`: extend each command with a VERSION branch; update usage lines to `REPO GROUP [CHANNEL] | REPO VERSION`.
- `client/pkg/client/client.go` + `interface.go`: new API — `UpdateRepoToVersion`, `UseRepoReleaseBinDir`, `ExecRepoReleaseBin`, `GetRepoReleaseBinDir`, `GetRepoReleaseDir`.
- `client/pkg/repo/update.go`: `UpdateToVersion` resolves a constraint to the greatest matching TUF release and marks it via `metafile/versions/<release>`.
- `client/pkg/repo/client.go`: `FindLocalReleaseByVersion` re-resolves a constraint against local pin markers; shared release-dir resolver refactored out of the channel path.
- `client/pkg/repo/clean_releases.go`: preserve pinned releases across `--autoclean`.
- `client/pkg/repo/use.go`: generate one source script per constraint (16-hex sha256 slug); emit env exports via `formatSourceScriptEnvExports` with per-shell literal/expression/unset modes; add `TRDL_USE_<REPO>_VERSION` (resolved release, evaluated at each shell source) and `TRDL_USE_<REPO>_VERSION_CONSTRAINT` (original selector).
- Symmetric telemetry env cleanup: source scripts and `Exec*Bin` clear the opposite mode's variables so a shell/binary never sees both sets.
- `server/path_publish.go`: reject group names starting with `"v"` in `ValidatePublishConfig` — a v-prefixed group would be indistinguishable from a version on the client side.
- `client/cmd/trdl/command/template.go`: fix the broken `{{if gt .Aliases 0}}` (compared `[]string` to `int`); enables the `Aliases:` help section and the new `download` alias on `update`.
- `client/cmd/trdl/command/md_docs.go`: render `## Aliases` in generated CLI partials; regenerate `docs/_includes/reference/cli/trdl_*.md`.
- Tests: `client/cmd/trdl/{common_test,version_flag_test}.go`, `client/pkg/repo/use_test.go` (env-export escaping + slug determinism), `e2e/tests/client/version_test.go` (exact/range/tilde/caret pins across `update`, `bin-path`, `dir-path`, `exec`, autoclean).
- CI: new `unit_client` job runs `task client:test:unit`; wired into the notify stage.

## Why

Users currently have to change publish configuration to expose a specific release version — there is no client-side path to pin one build reproducibly (e.g. in CI, Dockerfiles, or long-lived shell sessions). Pinning by exact version or by semver constraint gives users the same guarantees `go.mod`/`pip`/`npm` provide, without server-side coordination. The `download` alias on `update` reflects the second common use case (fetch-without-activate).

## Review focus / risks

- **Breaking: server-side v-prefixed group rejection.** Before this PR `semver.NewVersion("v3")` succeeded, so a `groups: [{name: v3}]` config was valid. It is now rejected at `publish` time. The client mode dispatcher relies on this invariant. Existing publish configs with v-prefixed group names must be renamed. Release notes / migration callout welcome.
- **Pinned releases accumulate.** `metafile/versions/<release>` markers are never expired and there is no `unpin` command. Repeated `trdl update REPO <constraint>` calls (e.g. daily in CI) pin every historical resolution result; `--autoclean` intentionally skips them. Consider a follow-up (`trdl unpin` or a TTL).
- **Shell startup cost shift.** Version-mode source scripts inline `$(trdl dir-path REPO 'constraint' | awk ...)` (`$(((trdl dir-path REPO 'constraint') -split '[\\/]')[-2])` on pwsh). Every new sourced shell forks `trdl` and acquires a shared release lock. Channel mode used a fixed literal.
- **Escaping surface.** `formatSourceScriptEnvExports` handles `'` in literal values (`'\''` unix, `''` pwsh) and keeps expressions in double quotes. The version constraint itself is inlined into the emitted script single-quoted without escaping — safe today because upstream `semver.NewConstraint` rejects `'`, but no defense in depth on the write side.
- **`isVersionArg` classification.** `^v\d`-prefixed → VERSION; parseable semver → GROUP; valid constraint → VERSION; otherwise → GROUP. Covered by `common_test.go`; worth a second pair of eyes on the ordering (semver-before-constraint is intentional so plain `1.2` stays a group).
- **`slugifyConstraint`.** Raw sha256 → 16 hex chars. `"1.2.0"` and `"=1.2.0"` produce different slugs → duplicate script files. Storage bloat only; no cleanup of the `scripts/` dir.
- **Template fix side-effect.** Cobra help output now renders `Aliases:` for the first time — any downstream doc scraper of `--help` will see new content.
