### PR TITLE
fix(server): make large git-repo clones interruptible

### DIFF
--- a/server/pkg/tasks_manager/actions.go
+++ b/server/pkg/tasks_manager/actions.go
@@ -157,7 +157,7 @@ func (m *Manager) queueTask(ctx context.Context, workerTaskFunc func(context.Con
 		return "", err
 	}
 
-	m.taskChan <- &worker.Task{Context: ctx, UUID: queuedTaskUUID, Action: workerTaskFunc}
+	m.taskChan <- &worker.Task{Context: context.WithoutCancel(ctx), UUID: queuedTaskUUID, Action: workerTaskFunc}
 
 	return queuedTaskUUID, nil
 }

--- a/server/pkg/tasks_manager/actions_test.go
+++ b/server/pkg/tasks_manager/actions_test.go
@@ -220,6 +220,26 @@ func TestManager_WrapTaskFunc(t *testing.T) {
 	<-doneCh
 }
 
+// TestManager_RunTaskDetachesRequestCtx verifies that canceling the caller's
+// context after RunTask returns does not propagate cancellation to the queued
+// task's context. Vault cancels the request ctx as soon as the plugin handler
+// returns, but the task must keep running in the background worker.
+func TestManager_RunTaskDetachesRequestCtx(t *testing.T) {
+	m := initManagerWithoutWorker()
+	storage := &logical.InmemStorage{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	uuid, err := m.RunTask(ctx, storage, noneTask)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, uuid)
+
+	cancel()
+
+	task := <-m.taskChan
+	assert.Equal(t, uuid, task.UUID)
+	assert.NoError(t, task.Context.Err(), "queued task ctx must survive request ctx cancellation")
+}
+
 func initManagerWithoutWorker() *Manager {
 	taskChan := make(chan *worker.Task, taskChanSize)
 	m := &Manager{taskChan: taskChan, logger: hclog.L()}


### PR DESCRIPTION
## Summary

Make cloning of large git repositories in `pathPublish`/`pathRelease` interruptible by the task timeout and by `pathTaskCancel`, and ensure the queued task itself survives Vault cancelling the request ctx as soon as the handler returns.

Supersedes #375 (which handled the first half of this problem).

## Key changes

- `server/pkg/git/repository.go` — `CloneInMemory` now accepts a ctx and calls `git.CloneContext` instead of `git.Clone`.
- `server/path_publish.go`, `server/path_release.go` — plumb ctx through `cloneGitRepositoryBranch` / `cloneGitRepositoryTag` into `CloneInMemory`; pass the Vault request ctx into `TasksManager.RunTask`; use `errors.Is(err, tasks_manager.ErrBusy)` instead of `err == …`.
- `server/pkg/git/signatures_test.go`, `server/pkg/git/signatures_loader_test.go` — update tests for the new signature.
- `server/pkg/tasks_manager/actions.go` — in `queueTask`, wrap the ctx handed to `worker.Task` with `context.WithoutCancel` so the queued task cannot be aborted by the caller's request-scoped cancellation.
- `server/pkg/tasks_manager/actions_test.go` — add `TestManager_RunTaskDetachesRequestCtx` regression.
- `server/pkg/tasks_manager/actions.go` — `err == ErrBusy` → `errors.Is(err, ErrBusy)`.

## Why

`git.Clone` (used in `CloneInMemory`) ignores any surrounding ctx. On a large repository the clone can dominate the task's wall time, and there was no way to stop it — the task timeout in `WrapTaskFunc` and `pathTaskCancel` fired but the clone kept running. Switching to `git.CloneContext` and threading the ctx from `RunTask` → task action → `CloneInMemory` fixes this.

That plumbing requires `RunTask` to receive a real ctx (previously `context.Background()`). The Vault plugin request ctx is the natural choice — it carries request-scoped values (logging, tracing) — but Vault's gRPC transport [cancels that ctx](https://github.com/hashicorp/vault/blob/main/sdk/plugin/grpc_backend_client.go) as soon as the plugin handler returns, which happens right after the UUID is written back to the client. Without the second change, the queued task's `worker.Task.Context` inherits that cancellation: `newJob` → `WrapTaskFunc` derive `jobContext`/`ctxWithTimeout` from it, and the `select` in `WrapTaskFunc` fires `<-ctxWithTimeout.Done()` before the clone can make meaningful progress — leaving the exact large-repo scenario the first half is trying to fix still broken. `context.WithoutCancel` in `queueTask` keeps the ctx values but drops the cancellation chain. Task timeout and `pathTaskCancel` remain the intended controls — they attach their own cancellation later in `newJob` and `WrapTaskFunc`.

## Review focus / risks

- `server/pkg/tasks_manager/actions.go` — the `context.WithoutCancel` boundary. Confirm no value on the Vault request ctx is expected to become invalid after request completion (audit logging, storage-view scoping). `logical.Storage` is passed separately and stored on the manager, so it is unaffected.
- Requires Go ≥ 1.21 for `context.WithoutCancel`; `server/go.mod` is 1.23. ✓
- `git.CloneContext` may surface previously silent errors (e.g. `context.DeadlineExceeded` on the 30-minute task timeout instead of a hung goroutine). Downstream error handling in `pathPublish`/`pathRelease` already wraps with `%w`, so `errors.Is` continues to work.
