### PR TITLE
fix(server): make large git-repo clones interruptible

### DIFF
--- a/server/path_publish.go
+++ b/server/path_publish.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -106,7 +107,7 @@ func (b *Backend) pathPublish(ctx context.Context, req *logical.Request, fields 
 		return nil, fmt.Errorf("error getting publisher repository: %w", err)
 	}
 
-	taskUUID, err := b.TasksManager.RunTask(context.Background(), req.Storage, func(ctx context.Context, storage logical.Storage) error {
+	taskUUID, err := b.TasksManager.RunTask(ctx, req.Storage, func(ctx context.Context, storage logical.Storage) error {
 		logboek.Context(ctx).Default().LogF("Started task\n")
 		b.Logger().Debug("Started task")
 
@@ -114,7 +115,7 @@ func (b *Backend) pathPublish(ctx context.Context, req *logical.Request, fields 
 		b.Logger().Debug("Cloning git repo")
 
 		gitBranch := cfg.GitTrdlChannelsBranch
-		gitRepo, err := cloneGitRepositoryBranch(cfg.GitRepoUrl, gitBranch, gitUsername, gitPassword)
+		gitRepo, err := cloneGitRepositoryBranch(ctx, cfg.GitRepoUrl, gitBranch, gitUsername, gitPassword)
 		if err != nil {
 			return fmt.Errorf("unable to clone git repository: %w", err)
 		}
@@ -203,7 +204,7 @@ func (b *Backend) pathPublish(ctx context.Context, req *logical.Request, fields 
 		return nil
 	})
 	if err != nil {
-		if err == tasks_manager.ErrBusy {
+		if errors.Is(err, tasks_manager.ErrBusy) {
 			return logical.ErrorResponse("busy"), nil
 		}
 
@@ -310,7 +311,7 @@ func NewErrIncorrectChannelName(chnl string) error {
 	return fmt.Errorf(`got incorrect channel name %q: expected "dev", "alpha", "beta", "ea", "stable" or "rock-solid"`, chnl)
 }
 
-func cloneGitRepositoryBranch(url, gitBranch, username, password string) (*git.Repository, error) {
+func cloneGitRepositoryBranch(ctx context.Context, url, gitBranch, username, password string) (*git.Repository, error) {
 	cloneGitOptions := trdlGit.CloneOptions{
 		BranchName:        gitBranch,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
@@ -323,7 +324,7 @@ func cloneGitRepositoryBranch(url, gitBranch, username, password string) (*git.R
 		}
 	}
 
-	gitRepo, err := trdlGit.CloneInMemory(url, cloneGitOptions)
+	gitRepo, err := trdlGit.CloneInMemory(ctx, url, cloneGitOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/server/path_release.go
+++ b/server/path_release.go
@@ -3,6 +3,7 @@ package server
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -114,14 +115,14 @@ func (b *Backend) pathRelease(ctx context.Context, req *logical.Request, fields 
 		return nil, fmt.Errorf("error getting publisher repository: %w", err)
 	}
 
-	taskUUID, err := b.TasksManager.RunTask(context.Background(), req.Storage, func(ctx context.Context, storage logical.Storage) error {
+	taskUUID, err := b.TasksManager.RunTask(ctx, req.Storage, func(ctx context.Context, storage logical.Storage) error {
 		logboek.Context(ctx).Default().LogF("Started task\n")
 		b.Logger().Debug("Started task")
 
 		logboek.Context(ctx).Default().LogF("Cloning git repo\n")
 		b.Logger().Debug("Cloning git repo")
 
-		gitRepo, err := cloneGitRepositoryTag(cfg.GitRepoUrl, gitTag, gitUsername, gitPassword)
+		gitRepo, err := cloneGitRepositoryTag(ctx, cfg.GitRepoUrl, gitTag, gitUsername, gitPassword)
 		if err != nil {
 			return fmt.Errorf("unable to clone git repository: %w", err)
 		}
@@ -222,7 +223,7 @@ func (b *Backend) pathRelease(ctx context.Context, req *logical.Request, fields 
 		return nil
 	})
 	if err != nil {
-		if err == tasks_manager.ErrBusy {
+		if errors.Is(err, tasks_manager.ErrBusy) {
 			return logical.ErrorResponse("busy"), nil
 		}
 
@@ -236,7 +237,7 @@ func (b *Backend) pathRelease(ctx context.Context, req *logical.Request, fields 
 	}, nil
 }
 
-func cloneGitRepositoryTag(url, gitTag, username, password string) (*git.Repository, error) {
+func cloneGitRepositoryTag(ctx context.Context, url, gitTag, username, password string) (*git.Repository, error) {
 	cloneGitOptions := trdlGit.CloneOptions{
 		TagName:           gitTag,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
@@ -249,7 +250,7 @@ func cloneGitRepositoryTag(url, gitTag, username, password string) (*git.Reposit
 		}
 	}
 
-	gitRepo, err := trdlGit.CloneInMemory(url, cloneGitOptions)
+	gitRepo, err := trdlGit.CloneInMemory(ctx, url, cloneGitOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/server/pkg/git/repository.go
+++ b/server/pkg/git/repository.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"archive/tar"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -24,7 +25,7 @@ type CloneOptions struct {
 	Auth              transport.AuthMethod
 }
 
-func CloneInMemory(url string, opts CloneOptions) (*git.Repository, error) {
+func CloneInMemory(ctx context.Context, url string, opts CloneOptions) (*git.Repository, error) {
 	storage := memory.NewStorage()
 	fs := memfs.New()
 
@@ -50,7 +51,7 @@ func CloneInMemory(url string, opts CloneOptions) (*git.Repository, error) {
 		}
 	}
 
-	return git.Clone(storage, fs, cloneOptions)
+	return git.CloneContext(ctx, storage, fs, cloneOptions)
 }
 
 func AddWorktreeFilesToTar(tw *tar.Writer, gitRepo *git.Repository) error {

--- a/server/pkg/git/signatures_loader_test.go
+++ b/server/pkg/git/signatures_loader_test.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -10,7 +12,9 @@ var _ = XDescribe("Signatures loader from git NOTES", func() {
 	It("successfully loads werf signatures", func() {
 		tagName := "v1.2.84+fix1"
 
-		repo, err := CloneInMemory("https://github.com/werf/werf.git", CloneOptions{TagName: tagName})
+		ctx := context.Background()
+
+		repo, err := CloneInMemory(ctx, "https://github.com/werf/werf.git", CloneOptions{TagName: tagName})
 		Expect(err).To(Succeed())
 
 		tref, err := repo.Tag(tagName)

--- a/server/pkg/git/signatures_test.go
+++ b/server/pkg/git/signatures_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	_ "embed"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -119,8 +120,10 @@ var _ = Describe("VerifyTagSignatures and VerifyCommitSignatures", func() {
 		expectedErrMsg                     string
 	}
 
+	ctx := context.Background()
+
 	tableItBodyTagFunc := func(entry tableEntry) {
-		repo, err := CloneInMemory(testDir, CloneOptions{})
+		repo, err := CloneInMemory(ctx, testDir, CloneOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 
 		err = VerifyTagSignatures(
@@ -140,7 +143,7 @@ var _ = Describe("VerifyTagSignatures and VerifyCommitSignatures", func() {
 	}
 
 	tableItBodyCommitFunc := func(entry tableEntry) {
-		repo, err := CloneInMemory(testDir, CloneOptions{})
+		repo, err := CloneInMemory(ctx, testDir, CloneOptions{})
 		Expect(err).ShouldNot(HaveOccurred())
 
 		head, err := repo.Head()

--- a/server/pkg/tasks_manager/actions.go
+++ b/server/pkg/tasks_manager/actions.go
@@ -40,7 +40,7 @@ func (m *Manager) RunTask(ctx context.Context, reqStorage logical.Storage, taskF
 func (m *Manager) AddOptionalTask(ctx context.Context, reqStorage logical.Storage, taskFunc func(context.Context, logical.Storage) error) (string, bool, error) {
 	taskUUID, err := m.RunTask(ctx, reqStorage, taskFunc)
 	if err != nil {
-		if err == ErrBusy {
+		if errors.Is(err, ErrBusy) {
 			return taskUUID, false, nil
 		}
 


### PR DESCRIPTION
## Summary

Make cloning of large git repositories in `pathPublish`/`pathRelease` interruptible by the task timeout and by `pathTaskCancel`. Reviving the useful half of the closed #375; the queued-task-ctx safety net it needs is already on `main` from #394.

## Key changes

- `server/pkg/git/repository.go` — `CloneInMemory` now accepts a ctx and calls `git.CloneContext` instead of `git.Clone`.
- `server/path_publish.go`, `server/path_release.go` — plumb ctx through `cloneGitRepositoryBranch` / `cloneGitRepositoryTag` into `CloneInMemory`; pass the Vault request ctx into `TasksManager.RunTask` so the clone inherits the task-timeout / `pathTaskCancel` ctx; use `errors.Is(err, tasks_manager.ErrBusy)` instead of `err == …`.
- `server/pkg/tasks_manager/actions.go` — `err == ErrBusy` → `errors.Is(err, ErrBusy)`.
- `server/pkg/git/signatures_test.go`, `server/pkg/git/signatures_loader_test.go` — update tests for the new signature.

## Why

`git.Clone` ignores any surrounding ctx. On a large repository the clone can dominate the task's wall time, and there was no way to stop it — `WrapTaskFunc`'s 30-minute task timeout and `pathTaskCancel` both fired but the clone kept running. Switching to `git.CloneContext` and threading the ctx from `RunTask` → task action → `CloneInMemory` fixes this.

Threading the ctx requires `RunTask` to receive a real ctx (previously `context.Background()`); the Vault request ctx is used because it carries request-scoped values (logging, tracing). Its cancellation cannot leak into the queued task — [Vault cancels that ctx](https://github.com/hashicorp/vault/blob/main/sdk/plugin/grpc_backend_client.go) as soon as the plugin handler returns — because #394 already wraps the ctx handed to `worker.Task` with `context.WithoutCancel` in `queueTask`. Task timeout and `pathTaskCancel` remain the intended controls: they attach their own cancellation later in `WrapTaskFunc`/`newJob` on top of the detached ctx.

Preserves the original commit from @ssr-zna (#375, closed).

## Review focus / risks

- `server/path_publish.go` / `server/path_release.go` — the switch from `context.Background()` to `ctx` at the `RunTask` call sites. Safe only because #394 landed; without it every publish/release task would die with `ErrContextCanceled` the moment Vault closes the request.
- `git.CloneContext` may surface previously silent errors (e.g. `context.DeadlineExceeded` on the 30-minute task timeout instead of a hung goroutine). Downstream error handling in `pathPublish`/`pathRelease` already wraps with `%w`, so `errors.Is` continues to work.
- No dependency changes.
