### PR TITLE
feat(server): make buildx driver configurable via env

### DIFF
--- a/docs/pages_en/QUICKSTART.md
+++ b/docs/pages_en/QUICKSTART.md
@@ -29,13 +29,22 @@ During a release, the plugin builds release artifacts with `docker buildx` in an
 On Kubernetes-native installations the build can instead be delegated to in-cluster BuildKit Pods using the buildx `kubernetes` driver. The driver is configured with environment variables of the Vault process:
 
 * `TRDL_BUILDX_DRIVER` — the buildx driver to use: `docker-container` (default) or `kubernetes`;
-* `TRDL_BUILDX_DRIVER_OPTS` — additional `--driver-opt` values for `docker buildx create`, one per line. Newline separation lets comma-containing values like `nodeselector=disktype=ssd,zone=a` pass through intact.
+* `TRDL_BUILDX_DRIVER_OPTS_<ANY_SUFFIX>` — additional `--driver-opt` values for `docker buildx create`. Any number of such variables can be set; each carries one or more values split by the separator. Values are applied in the lexicographic order of the variable names;
+* `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` — the separator for the values (`,` by default). A custom separator is needed when an option value itself contains commas, e.g. `nodeselector=disktype=ssd,zone=a`.
 
 An example configuration for the `kubernetes` driver:
 
 ```shell
 TRDL_BUILDX_DRIVER=kubernetes
-TRDL_BUILDX_DRIVER_OPTS=$'namespace=trdl-build\nrootless=true'
+TRDL_BUILDX_DRIVER_OPTS_KUBE=namespace=trdl-build,rootless=true
+```
+
+or the equivalent one-option-per-variable form:
+
+```shell
+TRDL_BUILDX_DRIVER=kubernetes
+TRDL_BUILDX_DRIVER_OPTS_NAMESPACE=namespace=trdl-build
+TRDL_BUILDX_DRIVER_OPTS_ROOTLESS=rootless=true
 ```
 
 Notes on the `kubernetes` driver:

--- a/docs/pages_en/QUICKSTART.md
+++ b/docs/pages_en/QUICKSTART.md
@@ -22,6 +22,29 @@ Install Docker. Add a Vault user to the Docker group:
 usermod -a -G docker vault
 ```
 
+### Build backend
+
+During a release, the plugin builds release artifacts with `docker buildx` in an ephemeral per-build builder. By default the `docker-container` driver is used, which requires access to the Docker daemon (see above).
+
+On Kubernetes-native installations the build can instead be delegated to in-cluster BuildKit Pods using the buildx `kubernetes` driver. The driver is configured with environment variables of the Vault process:
+
+* `TRDL_BUILDX_DRIVER` — the buildx driver to use: `docker-container` (default) or `kubernetes`;
+* `TRDL_BUILDX_DRIVER_OPTS` — additional `--driver-opt` values for `docker buildx create`, one per line. Newline separation lets comma-containing values like `nodeselector=disktype=ssd,zone=a` pass through intact.
+
+An example configuration for the `kubernetes` driver:
+
+```shell
+TRDL_BUILDX_DRIVER=kubernetes
+TRDL_BUILDX_DRIVER_OPTS=$'namespace=trdl-build\nrootless=true'
+```
+
+Notes on the `kubernetes` driver:
+
+* the target namespace must exist, and the Vault process needs permissions to manage Deployments and Pods in it: the builder runs as a BuildKit Deployment and is removed after the build;
+* the cluster is targeted via the standard kubeconfig or in-cluster ServiceAccount resolution;
+* rootless BuildKit (`rootless=true`) requires the PodSecurity level `baseline`; it does not run under `restricted`;
+* see the [buildx kubernetes driver documentation](https://docs.docker.com/build/builders/drivers/kubernetes/) for the available driver options.
+
 ### Setting up the project
 
 #### Git repository

--- a/docs/pages_ru/QUICKSTART.md
+++ b/docs/pages_ru/QUICKSTART.md
@@ -28,13 +28,22 @@ usermod -a -G docker vault
 В Kubernetes-инсталляциях сборку можно делегировать BuildKit-подам внутри кластера, используя buildx-драйвер `kubernetes`. Драйвер настраивается переменными окружения процесса Vault:
 
 * `TRDL_BUILDX_DRIVER` — используемый buildx-драйвер: `docker-container` (по умолчанию) или `kubernetes`;
-* `TRDL_BUILDX_DRIVER_OPTS` — дополнительные значения `--driver-opt` для `docker buildx create`, по одному на строку. Разделение переводами строк позволяет передавать значения с запятыми, например `nodeselector=disktype=ssd,zone=a`.
+* `TRDL_BUILDX_DRIVER_OPTS_<ЛЮБОЙ_СУФФИКС>` — дополнительные значения `--driver-opt` для `docker buildx create`. Таких переменных может быть любое количество; каждая содержит одно или несколько значений, разделённых разделителем. Значения применяются в лексикографическом порядке имён переменных;
+* `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` — разделитель значений (по умолчанию `,`). Пользовательский разделитель нужен, когда само значение опции содержит запятые, например `nodeselector=disktype=ssd,zone=a`.
 
 Пример конфигурации для драйвера `kubernetes`:
 
 ```shell
 TRDL_BUILDX_DRIVER=kubernetes
-TRDL_BUILDX_DRIVER_OPTS=$'namespace=trdl-build\nrootless=true'
+TRDL_BUILDX_DRIVER_OPTS_KUBE=namespace=trdl-build,rootless=true
+```
+
+или эквивалентная форма «одна опция — одна переменная»:
+
+```shell
+TRDL_BUILDX_DRIVER=kubernetes
+TRDL_BUILDX_DRIVER_OPTS_NAMESPACE=namespace=trdl-build
+TRDL_BUILDX_DRIVER_OPTS_ROOTLESS=rootless=true
 ```
 
 Особенности драйвера `kubernetes`:

--- a/docs/pages_ru/QUICKSTART.md
+++ b/docs/pages_ru/QUICKSTART.md
@@ -21,6 +21,29 @@ toc_headers: h2
 usermod -a -G docker vault
 ```
 
+### Сборочный бекенд
+
+Во время релиза плагин собирает релизные артефакты с помощью `docker buildx` во временном сборщике, создаваемом на каждую сборку. По умолчанию используется драйвер `docker-container`, которому нужен доступ к Docker-демону (см. выше).
+
+В Kubernetes-инсталляциях сборку можно делегировать BuildKit-подам внутри кластера, используя buildx-драйвер `kubernetes`. Драйвер настраивается переменными окружения процесса Vault:
+
+* `TRDL_BUILDX_DRIVER` — используемый buildx-драйвер: `docker-container` (по умолчанию) или `kubernetes`;
+* `TRDL_BUILDX_DRIVER_OPTS` — дополнительные значения `--driver-opt` для `docker buildx create`, по одному на строку. Разделение переводами строк позволяет передавать значения с запятыми, например `nodeselector=disktype=ssd,zone=a`.
+
+Пример конфигурации для драйвера `kubernetes`:
+
+```shell
+TRDL_BUILDX_DRIVER=kubernetes
+TRDL_BUILDX_DRIVER_OPTS=$'namespace=trdl-build\nrootless=true'
+```
+
+Особенности драйвера `kubernetes`:
+
+* целевой namespace должен существовать, а процессу Vault нужны права на управление Deployment и Pod в нём: сборщик работает как BuildKit Deployment и удаляется после сборки;
+* кластер определяется стандартным способом — через kubeconfig или in-cluster ServiceAccount;
+* rootless BuildKit (`rootless=true`) требует уровень PodSecurity `baseline`; под `restricted` он не работает;
+* доступные опции драйвера — в [документации buildx kubernetes driver](https://docs.docker.com/build/builders/drivers/kubernetes/).
+
 ### Подготовка проекта
 
 #### Git-репозиторий

--- a/e2e/tests/mac_signing/_fixtures/complete_cycle/docker-compose.yaml
+++ b/e2e/tests/mac_signing/_fixtures/complete_cycle/docker-compose.yaml
@@ -1,0 +1,20 @@
+networks:
+  minio-net:
+
+services:
+  minio:
+    image: minio/minio@sha256:36433a735d87bbc2fed55674b3af936b57259f5cd2c544e869b8276d4d22b590
+    ports:
+      - "9000"
+    command: server /data
+    networks:
+      - minio-net
+
+  mc:
+    image: minio/mc@sha256:f78c05169b54f191ab407a8e4d746a2b1f65a047936ba0e51885504912c9595e
+    depends_on:
+      - minio
+    environment:
+      MC_HOST_main: http://minioadmin:minioadmin@minio:9000
+    networks:
+      - minio-net

--- a/e2e/tests/mac_signing/_fixtures/complete_cycle/trdl.yaml
+++ b/e2e/tests/mac_signing/_fixtures/complete_cycle/trdl.yaml
@@ -1,0 +1,4 @@
+dockerImage: alpine@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a
+commands:
+  - mkdir -p /result/any-any/bin
+  - printf '\317\372\355\376\007\000\000\001' > /result/any-any/bin/macho-stub

--- a/e2e/tests/mac_signing/_fixtures/pgp_keys
+++ b/e2e/tests/mac_signing/_fixtures/pgp_keys
@@ -1,0 +1,1 @@
+../../../../server/pkg/git/_fixtures/pgp_keys

--- a/e2e/tests/mac_signing/_fixtures/quill_stub/Dockerfile
+++ b/e2e/tests/mac_signing/_fixtures/quill_stub/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.20
+RUN apk add --no-cache file
+COPY quill /usr/local/bin/quill
+RUN chmod +x /usr/local/bin/quill

--- a/e2e/tests/mac_signing/_fixtures/quill_stub/quill
+++ b/e2e/tests/mac_signing/_fixtures/quill_stub/quill
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+if [ "$1" != "sign-and-notarize" ]; then
+	echo "quill stub: unexpected args: $*" >&2
+	exit 1
+fi
+for v in QUILL_SIGN_P12 QUILL_SIGN_PASSWORD QUILL_NOTARY_KEY_ID QUILL_NOTARY_KEY QUILL_NOTARY_ISSUER; do
+	eval "val=\${$v}"
+	if [ -z "$val" ]; then
+		echo "quill stub: $v is empty" >&2
+		exit 1
+	fi
+done
+printf 'TRDL-E2E-STUB-SIGNED:%s:%s' "$QUILL_SIGN_P12" "$QUILL_NOTARY_KEY_ID" >>"$2"

--- a/e2e/tests/mac_signing/complete_cycle_ai_test.go
+++ b/e2e/tests/mac_signing/complete_cycle_ai_test.go
@@ -1,0 +1,173 @@
+//go:build ai_tests
+// +build ai_tests
+
+package mac_signing
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault/sdk/logical"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/trdl/server"
+	tasksManagerTestutil "github.com/werf/trdl/server/pkg/tasks_manager/testutil"
+	"github.com/werf/trdl/server/pkg/testutil"
+)
+
+// The suite proves trdl's mac-signing plumbing end to end without Apple
+// credentials: TRDL_QUILL_IMAGE must point at a stub image (built from
+// _fixtures/quill_stub) whose quill validates the five QUILL_* env vars and
+// appends a marker with the received cert and notary key id to the artifact.
+// Asserting the marker in the published artifact proves the Vault-stored
+// credential values travelled through the buildkit secret mounts into the
+// signer stage, the Mach-O detection loop ran, and the "signed" artifact was
+// re-exported through the final scratch stage.
+var _ = Describe("Mac signing", func() {
+	var storage logical.Storage
+	var backend *server.Backend
+	var minioAddress string
+
+	certificate := base64.StdEncoding.EncodeToString([]byte("dummy-mac-signing-certificate"))
+	notaryKey := base64.StdEncoding.EncodeToString([]byte("dummy-notary-key"))
+
+	const (
+		tag     = "v1.0.1"
+		version = "1.0.1"
+
+		password     = "dummy-password"
+		notaryKeyID  = "dummy-notary-key-id"
+		notaryIssuer = "dummy-notary-issuer"
+
+		machOMagic = "\317\372\355\376\007\000\000\001"
+
+		pgpSigningKeyDeveloper = "74E1259029B147CB4033E8B80D4C9C140E8A1030"
+		pgpSigningKeyTL        = "2BA55FD8158034EEBE92AA9ED9D79B63AFC30C7A"
+		pgpSigningKeyPM        = "C353F279F552B3EF16DAE0A64354E51BF178F735"
+	)
+
+	handleRequest := func(path string, data map[string]interface{}) *logical.Response {
+		req := &logical.Request{Storage: storage}
+		req.Path = path
+		req.Operation = logical.CreateOperation
+		req.Data = data
+		resp, err := backend.HandleRequest(context.Background(), req)
+		Expect(err).ShouldNot(HaveOccurred())
+		return resp
+	}
+
+	BeforeEach(func() {
+		if os.Getenv("TRDL_QUILL_IMAGE") == "" {
+			Skip("TRDL_QUILL_IMAGE is not set; build and push _fixtures/quill_stub to a registry reachable by the buildkit builder and point TRDL_QUILL_IMAGE at it")
+		}
+
+		testutil.RunSucceedCommand(
+			testutil.FixturePath("pgp_keys"),
+			"gpg",
+			"--import",
+			"developer_private.pgp",
+			"tl_private.pgp",
+			"pm_private.pgp",
+		)
+
+		var err error
+		backend, err = server.NewBackend(hclog.L())
+		Expect(err).ShouldNot(HaveOccurred())
+		storage = &logical.InmemStorage{}
+
+		config := logical.TestBackendConfig()
+		config.StorageView = storage
+		Expect(backend.Setup(context.Background(), config)).To(Succeed())
+
+		testutil.CopyIn(testutil.FixturePath("complete_cycle"), testDir)
+		testutil.RunSucceedCommand(testDir, "git", "-c", "init.defaultBranch=main", "init")
+		testutil.RunSucceedCommand(testDir, "git", "add", "-A")
+		testutil.RunSucceedCommand(testDir, "git", "commit", "-m", "Initial commit")
+
+		testutil.RunSucceedCommand(testDir, "docker", "compose", "up", "--detach")
+		testutil.RunSucceedCommand(testDir, "docker", "compose", "run", "mc", "mb", "main/repo")
+		testutil.RunSucceedCommand(testDir, "docker", "compose", "run", "mc", "policy", "set", "download", "main/repo")
+
+		output := testutil.SucceedCommandOutputString(testDir, "docker", "compose", "port", "minio", "9000")
+		minioAddress = "http://" + strings.TrimSpace(output)
+	})
+
+	AfterEach(func() {
+		testutil.RunSucceedCommand(testDir, "docker", "compose", "down")
+	})
+
+	It("signs Mach-O release artifacts through the quill stage", func() {
+		By("[server] Configuring ...")
+		handleRequest("configure", map[string]interface{}{
+			"git_repo_url":                                     testDir,
+			"git_trdl_channels_branch":                         "main",
+			"initial_last_published_git_commit":                "",
+			"required_number_of_verified_signatures_on_commit": 3,
+			"s3_endpoint":                                      minioAddress,
+			"s3_region":                                        "ru-central1",
+			"s3_access_key_id":                                 "minioadmin",
+			"s3_secret_access_key":                             "minioadmin",
+			"s3_bucket_name":                                   "repo",
+		})
+
+		for _, user := range []string{"developer", "tl", "pm"} {
+			data, err := os.ReadFile(testutil.FixturePath("pgp_keys", fmt.Sprintf("%s_public.pgp", user)))
+			Expect(err).ShouldNot(HaveOccurred())
+			handleRequest("configure/trusted_pgp_public_key", map[string]interface{}{
+				"name":       user,
+				"public_key": string(data),
+			})
+		}
+
+		By("[server] Configuring mac signing credentials ...")
+		handleRequest("configure/build/mac_signing_identity", map[string]interface{}{
+			"data":          certificate,
+			"password":      password,
+			"notary_key_id": notaryKeyID,
+			"notary_key":    notaryKey,
+			"notary_issuer": notaryIssuer,
+		})
+
+		By("[git] Tagging and quorum-signing " + tag + " ...")
+		testutil.RunSucceedCommand(
+			testDir,
+			"git",
+			"-c", "tag.gpgsign=true",
+			"-c", "user.signingkey="+pgpSigningKeyDeveloper,
+			"tag", tag, "-m", "New version",
+		)
+		for _, key := range []string{pgpSigningKeyTL, pgpSigningKeyPM} {
+			testutil.RunSucceedCommand(testDir, "git", "signatures", "add", "--key", key, tag)
+			testutil.RunSucceedCommand(testDir, "git", "signatures", "add", "--key", key, "main")
+		}
+
+		By("[server] Releasing " + tag + " ...")
+		resp := handleRequest("release", map[string]interface{}{"git_tag": tag})
+		Expect(resp).ShouldNot(BeNil())
+		taskUUID, ok := resp.Data["task_uuid"].(string)
+		Expect(ok).Should(BeTrue(), fmt.Sprintf("%+v", resp.Data))
+		tasksManagerTestutil.WaitForTaskSuccess(GinkgoWriter, GinkgoT(), context.Background(), backend, storage, taskUUID)
+
+		By("[minio] Verifying the published artifact was signed by the quill stage ...")
+		artifactURL := fmt.Sprintf("%s/repo/targets/releases/%s/any-any/bin/macho-stub", minioAddress, version)
+		httpResp, err := http.Get(artifactURL)
+		Expect(err).ShouldNot(HaveOccurred())
+		defer func() { _ = httpResp.Body.Close() }()
+		Expect(httpResp.StatusCode).Should(Equal(http.StatusOK))
+
+		artifact, err := io.ReadAll(httpResp.Body)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(string(artifact)).Should(HavePrefix(machOMagic),
+			"the Mach-O stub payload must survive the signer stage")
+		Expect(string(artifact)).Should(HaveSuffix(fmt.Sprintf("TRDL-E2E-STUB-SIGNED:%s:%s", certificate, notaryKeyID)),
+			"the credential values stored in Vault must reach quill through the buildkit secret mounts")
+	})
+})

--- a/e2e/tests/mac_signing/doc.go
+++ b/e2e/tests/mac_signing/doc.go
@@ -1,0 +1,6 @@
+// Package mac_signing holds the mac-signing e2e suite. This file carries no
+// build tag so the package is not fully excluded when the ai_tests tag is
+// off: ginkgo fails a package whose every Go file is build-constrained out
+// ("build constraints exclude all Go files"), whereas one untagged file makes
+// it skip.
+package mac_signing

--- a/e2e/tests/mac_signing/suite_ai_test.go
+++ b/e2e/tests/mac_signing/suite_ai_test.go
@@ -1,0 +1,37 @@
+//go:build ai_tests
+// +build ai_tests
+
+package mac_signing
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/trdl/server/pkg/testutil"
+)
+
+func TestAI_MacSigning(t *testing.T) {
+	testutil.MeetsRequirementTools([]string{"docker", "git", "git-signatures", "gpg"})
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mac Signing Suite")
+}
+
+var (
+	tmpDir  string
+	testDir string
+)
+
+var _ = BeforeEach(func() {
+	tmpDir = testutil.GetTempDir()
+
+	testDir = filepath.Join(tmpDir, "project")
+	Expect(os.Mkdir(testDir, os.ModePerm)).To(Succeed())
+})
+
+var _ = AfterEach(func() {
+	Expect(os.RemoveAll(tmpDir)).To(Succeed())
+})

--- a/server/pkg/docker/builder.go
+++ b/server/pkg/docker/builder.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/djherbis/nio/v3"
+	"github.com/samber/lo"
 
 	"github.com/werf/logboek"
 	"github.com/werf/trdl/server/pkg/mac_signing"
@@ -18,11 +19,8 @@ import (
 )
 
 const (
-	// buildxDriverEnv overrides the buildx driver used to create the ephemeral
-	// per-build builder. Unset preserves the historical docker-container builder.
 	buildxDriverEnv = "TRDL_BUILDX_DRIVER"
-	// buildxDriverOptsEnv passes buildx `--driver-opt` values, one per line, e.g.
-	// "namespace=trdl-build\nrootless=true" for the kubernetes driver.
+	// One `--driver-opt` per line, e.g. "namespace=trdl-build\nrootless=true".
 	buildxDriverOptsEnv = "TRDL_BUILDX_DRIVER_OPTS"
 
 	defaultBuildxDriver = "docker-container"
@@ -33,10 +31,7 @@ const (
 // driver cannot export; only full-BuildKit drivers are accepted, so an
 // unsupported driver fails closed here with a clear error rather than later with
 // an opaque build failure.
-var supportedBuildxDrivers = map[string]bool{
-	"docker-container": true,
-	"kubernetes":       true,
-}
+var supportedBuildxDrivers = []string{"docker-container", "kubernetes"}
 
 type Logger interface {
 	Info(msg string, args ...interface{})
@@ -62,7 +57,7 @@ func NewBuilder(ctx context.Context, opts *NewBuilderOpts) (*Builder, error) {
 
 	builderArgs, err := buildxCreateArgs(builderName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to construct buildx create args: %w", err)
 	}
 
 	if err := runDockerCmd(ctx, builderArgs); err != nil {
@@ -81,16 +76,13 @@ func NewBuilder(ctx context.Context, opts *NewBuilderOpts) (*Builder, error) {
 	}, nil
 }
 
-// buildxCreateArgs builds the `docker buildx create` arguments for builderName,
-// honouring TRDL_BUILDX_DRIVER / TRDL_BUILDX_DRIVER_OPTS. With neither set it is
-// identical to the historical `--driver=docker-container` invocation.
 func buildxCreateArgs(builderName string) ([]string, error) {
 	driver := os.Getenv(buildxDriverEnv)
 	if driver == "" {
 		driver = defaultBuildxDriver
 	}
-	if !supportedBuildxDrivers[driver] {
-		return nil, fmt.Errorf("unsupported buildx driver %q from %s (supported: docker-container, kubernetes)", driver, buildxDriverEnv)
+	if !lo.Contains(supportedBuildxDrivers, driver) {
+		return nil, fmt.Errorf("unsupported buildx driver %q from %s (supported: %s)", driver, buildxDriverEnv, strings.Join(supportedBuildxDrivers, ", "))
 	}
 
 	args := []string{
@@ -106,9 +98,8 @@ func buildxCreateArgs(builderName string) ([]string, error) {
 	return args, nil
 }
 
-// parseDriverOpts splits raw into individual buildx `--driver-opt` values, one
-// per non-blank line. Newline separation keeps commas intact for CSV-valued
-// opts such as nodeselector/tolerations.
+// Newline separation keeps commas intact for CSV-valued opts such as
+// nodeselector/tolerations.
 func parseDriverOpts(raw string) []string {
 	var opts []string
 	for _, line := range strings.Split(raw, "\n") {

--- a/server/pkg/docker/builder.go
+++ b/server/pkg/docker/builder.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/djherbis/nio/v3"
 
@@ -14,6 +16,27 @@ import (
 	"github.com/werf/trdl/server/pkg/mac_signing"
 	"github.com/werf/trdl/server/pkg/secrets"
 )
+
+const (
+	// buildxDriverEnv overrides the buildx driver used to create the ephemeral
+	// per-build builder. Unset preserves the historical docker-container builder.
+	buildxDriverEnv = "TRDL_BUILDX_DRIVER"
+	// buildxDriverOptsEnv passes buildx `--driver-opt` values, one per line, e.g.
+	// "namespace=trdl-build\nrootless=true" for the kubernetes driver.
+	buildxDriverOptsEnv = "TRDL_BUILDX_DRIVER_OPTS"
+
+	defaultBuildxDriver = "docker-container"
+)
+
+// supportedBuildxDrivers are the drivers trdl will create a builder for. The
+// build streams a tarball to stdout (`-o - -`), which the default "docker"
+// driver cannot export; only full-BuildKit drivers are accepted, so an
+// unsupported driver fails closed here with a clear error rather than later with
+// an opaque build failure.
+var supportedBuildxDrivers = map[string]bool{
+	"docker-container": true,
+	"kubernetes":       true,
+}
 
 type Logger interface {
 	Info(msg string, args ...interface{})
@@ -36,11 +59,10 @@ type NewBuilderOpts struct {
 
 func NewBuilder(ctx context.Context, opts *NewBuilderOpts) (*Builder, error) {
 	builderName := fmt.Sprintf("trdl-builder-%s", opts.BuildId)
-	builderArgs := []string{
-		"buildx",
-		"create",
-		"--name", builderName,
-		"--driver=docker-container",
+
+	builderArgs, err := buildxCreateArgs(builderName)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := runDockerCmd(ctx, builderArgs); err != nil {
@@ -57,6 +79,45 @@ func NewBuilder(ctx context.Context, opts *NewBuilderOpts) (*Builder, error) {
 		buildArgs:   args,
 		logger:      opts.Logger,
 	}, nil
+}
+
+// buildxCreateArgs builds the `docker buildx create` arguments for builderName,
+// honouring TRDL_BUILDX_DRIVER / TRDL_BUILDX_DRIVER_OPTS. With neither set it is
+// identical to the historical `--driver=docker-container` invocation.
+func buildxCreateArgs(builderName string) ([]string, error) {
+	driver := os.Getenv(buildxDriverEnv)
+	if driver == "" {
+		driver = defaultBuildxDriver
+	}
+	if !supportedBuildxDrivers[driver] {
+		return nil, fmt.Errorf("unsupported buildx driver %q from %s (supported: docker-container, kubernetes)", driver, buildxDriverEnv)
+	}
+
+	args := []string{
+		"buildx",
+		"create",
+		"--name", builderName,
+		"--driver=" + driver,
+	}
+	for _, opt := range parseDriverOpts(os.Getenv(buildxDriverOptsEnv)) {
+		args = append(args, "--driver-opt="+opt)
+	}
+
+	return args, nil
+}
+
+// parseDriverOpts splits raw into individual buildx `--driver-opt` values, one
+// per non-blank line. Newline separation keeps commas intact for CSV-valued
+// opts such as nodeselector/tolerations.
+func parseDriverOpts(raw string) []string {
+	var opts []string
+	for _, line := range strings.Split(raw, "\n") {
+		if v := strings.TrimSpace(line); v != "" {
+			opts = append(opts, v)
+		}
+	}
+
+	return opts
 }
 
 func (b *Builder) Build(ctx context.Context, contextReader *nio.PipeReader, tarWriter *nio.PipeWriter) error {

--- a/server/pkg/docker/builder.go
+++ b/server/pkg/docker/builder.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/djherbis/nio/v3"
@@ -20,10 +21,13 @@ import (
 
 const (
 	buildxDriverEnv = "TRDL_BUILDX_DRIVER"
-	// One `--driver-opt` per line, e.g. "namespace=trdl-build\nrootless=true".
-	buildxDriverOptsEnv = "TRDL_BUILDX_DRIVER_OPTS"
+	// Every TRDL_BUILDX_DRIVER_OPTS_<SUFFIX> variable carries `--driver-opt`
+	// values split by the separator, e.g. TRDL_BUILDX_DRIVER_OPTS_KUBE="namespace=trdl-build,rootless=true".
+	buildxDriverOptsEnvPrefix    = "TRDL_BUILDX_DRIVER_OPTS_"
+	buildxDriverOptsSeparatorEnv = "TRDL_BUILDX_DRIVER_OPTS_SEPARATOR"
 
-	defaultBuildxDriver = "docker-container"
+	defaultBuildxDriver              = "docker-container"
+	defaultBuildxDriverOptsSeparator = ","
 )
 
 // supportedBuildxDrivers are the drivers trdl will create a builder for. The
@@ -91,19 +95,39 @@ func buildxCreateArgs(builderName string) ([]string, error) {
 		"--name", builderName,
 		"--driver=" + driver,
 	}
-	for _, opt := range parseDriverOpts(os.Getenv(buildxDriverOptsEnv)) {
+	for _, opt := range driverOptsFromEnv() {
 		args = append(args, "--driver-opt="+opt)
 	}
 
 	return args, nil
 }
 
-// Newline separation keeps commas intact for CSV-valued opts such as
-// nodeselector/tolerations.
-func parseDriverOpts(raw string) []string {
+func driverOptsFromEnv() []string {
+	separator := os.Getenv(buildxDriverOptsSeparatorEnv)
+	if separator == "" {
+		separator = defaultBuildxDriverOptsSeparator
+	}
+
 	var opts []string
-	for _, line := range strings.Split(raw, "\n") {
-		if v := strings.TrimSpace(line); v != "" {
+	env := os.Environ()
+	sort.Strings(env)
+	for _, keyValue := range env {
+		name, value, _ := strings.Cut(keyValue, "=")
+		if !strings.HasPrefix(name, buildxDriverOptsEnvPrefix) || name == buildxDriverOptsSeparatorEnv {
+			continue
+		}
+		opts = append(opts, parseDriverOpts(value, separator)...)
+	}
+
+	return opts
+}
+
+// CSV-valued opts such as nodeselector/tolerations need a custom separator or
+// the one-opt-per-variable form to survive the comma-separated default.
+func parseDriverOpts(raw, separator string) []string {
+	var opts []string
+	for _, part := range strings.Split(raw, separator) {
+		if v := strings.TrimSpace(part); v != "" {
 			opts = append(opts, v)
 		}
 	}

--- a/server/pkg/docker/builder.go
+++ b/server/pkg/docker/builder.go
@@ -77,7 +77,7 @@ func NewBuilder(ctx context.Context, opts *NewBuilderOpts) (*Builder, error) {
 }
 
 func buildxCreateArgs(builderName string) ([]string, error) {
-	driver := os.Getenv(buildxDriverEnv)
+	driver := strings.TrimSpace(os.Getenv(buildxDriverEnv))
 	if driver == "" {
 		driver = defaultBuildxDriver
 	}

--- a/server/pkg/docker/builder_test.go
+++ b/server/pkg/docker/builder_test.go
@@ -1,0 +1,58 @@
+package docker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildxCreateArgs_DefaultDriverUnchanged(t *testing.T) {
+	// With no env set the invocation must stay byte-for-byte the historical one.
+	t.Setenv(buildxDriverEnv, "")
+	t.Setenv(buildxDriverOptsEnv, "")
+
+	args, err := buildxCreateArgs("trdl-builder-42")
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{
+		"buildx", "create",
+		"--name", "trdl-builder-42",
+		"--driver=docker-container",
+	}, args)
+}
+
+func TestBuildxCreateArgs_KubernetesDriverWithOpts(t *testing.T) {
+	t.Setenv(buildxDriverEnv, "kubernetes")
+	t.Setenv(buildxDriverOptsEnv, "namespace=trdl-build\nrootless=true")
+
+	args, err := buildxCreateArgs("trdl-builder-42")
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{
+		"buildx", "create",
+		"--name", "trdl-builder-42",
+		"--driver=kubernetes",
+		"--driver-opt=namespace=trdl-build",
+		"--driver-opt=rootless=true",
+	}, args)
+}
+
+func TestBuildxCreateArgs_UnsupportedDriverRejected(t *testing.T) {
+	// The default "docker" driver cannot export the stdout tarball, so it must
+	// be rejected up front rather than failing opaquely during the build.
+	t.Setenv(buildxDriverEnv, "docker")
+	t.Setenv(buildxDriverOptsEnv, "")
+
+	_, err := buildxCreateArgs("trdl-builder-42")
+
+	assert.Error(t, err)
+}
+
+func TestParseDriverOpts(t *testing.T) {
+	assert.Nil(t, parseDriverOpts(""))
+	assert.Nil(t, parseDriverOpts("\n  \n"))
+	assert.Equal(t,
+		[]string{"namespace=trdl-build", "nodeselector=disktype=ssd,zone=a"},
+		parseDriverOpts("  namespace=trdl-build \n\n nodeselector=disktype=ssd,zone=a \n"),
+	)
+}

--- a/server/pkg/docker/builder_test.go
+++ b/server/pkg/docker/builder_test.go
@@ -4,16 +4,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildxCreateArgs_DefaultDriverUnchanged(t *testing.T) {
-	// With no env set the invocation must stay byte-for-byte the historical one.
 	t.Setenv(buildxDriverEnv, "")
 	t.Setenv(buildxDriverOptsEnv, "")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"buildx", "create",
 		"--name", "trdl-builder-42",
@@ -27,7 +27,7 @@ func TestBuildxCreateArgs_KubernetesDriverWithOpts(t *testing.T) {
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []string{
 		"buildx", "create",
 		"--name", "trdl-builder-42",
@@ -37,15 +37,32 @@ func TestBuildxCreateArgs_KubernetesDriverWithOpts(t *testing.T) {
 	}, args)
 }
 
+func TestBuildxCreateArgs_DefaultDriverWithOpts(t *testing.T) {
+	t.Setenv(buildxDriverEnv, "")
+	t.Setenv(buildxDriverOptsEnv, "image=moby/buildkit:v0.12.0\nnetwork=host")
+
+	args, err := buildxCreateArgs("trdl-builder-42")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"buildx", "create",
+		"--name", "trdl-builder-42",
+		"--driver=docker-container",
+		"--driver-opt=image=moby/buildkit:v0.12.0",
+		"--driver-opt=network=host",
+	}, args)
+}
+
 func TestBuildxCreateArgs_UnsupportedDriverRejected(t *testing.T) {
-	// The default "docker" driver cannot export the stdout tarball, so it must
-	// be rejected up front rather than failing opaquely during the build.
 	t.Setenv(buildxDriverEnv, "docker")
 	t.Setenv(buildxDriverOptsEnv, "")
 
-	_, err := buildxCreateArgs("trdl-builder-42")
+	args, err := buildxCreateArgs("trdl-builder-42")
 
-	assert.Error(t, err)
+	require.Error(t, err)
+	assert.Nil(t, args)
+	assert.Contains(t, err.Error(), `"docker"`)
+	assert.Contains(t, err.Error(), buildxDriverEnv)
 }
 
 func TestParseDriverOpts(t *testing.T) {

--- a/server/pkg/docker/builder_test.go
+++ b/server/pkg/docker/builder_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestBuildxCreateArgs_DefaultDriverUnchanged(t *testing.T) {
 	t.Setenv(buildxDriverEnv, "")
-	t.Setenv(buildxDriverOptsEnv, "")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
@@ -23,7 +22,7 @@ func TestBuildxCreateArgs_DefaultDriverUnchanged(t *testing.T) {
 
 func TestBuildxCreateArgs_KubernetesDriverWithOpts(t *testing.T) {
 	t.Setenv(buildxDriverEnv, "kubernetes")
-	t.Setenv(buildxDriverOptsEnv, "namespace=trdl-build\nrootless=true")
+	t.Setenv(buildxDriverOptsEnvPrefix+"KUBE", "namespace=trdl-build,rootless=true")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
@@ -39,7 +38,7 @@ func TestBuildxCreateArgs_KubernetesDriverWithOpts(t *testing.T) {
 
 func TestBuildxCreateArgs_DefaultDriverWithOpts(t *testing.T) {
 	t.Setenv(buildxDriverEnv, "")
-	t.Setenv(buildxDriverOptsEnv, "image=moby/buildkit:v0.12.0\nnetwork=host")
+	t.Setenv(buildxDriverOptsEnvPrefix+"CONTAINER", "image=moby/buildkit:v0.12.0,network=host")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
@@ -55,7 +54,6 @@ func TestBuildxCreateArgs_DefaultDriverWithOpts(t *testing.T) {
 
 func TestBuildxCreateArgs_DriverValueTrimmed(t *testing.T) {
 	t.Setenv(buildxDriverEnv, "  kubernetes  ")
-	t.Setenv(buildxDriverOptsEnv, "")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
@@ -65,7 +63,6 @@ func TestBuildxCreateArgs_DriverValueTrimmed(t *testing.T) {
 
 func TestBuildxCreateArgs_UnsupportedDriverRejected(t *testing.T) {
 	t.Setenv(buildxDriverEnv, "docker")
-	t.Setenv(buildxDriverOptsEnv, "")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
@@ -75,11 +72,52 @@ func TestBuildxCreateArgs_UnsupportedDriverRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), buildxDriverEnv)
 }
 
+func TestBuildxCreateArgs_CustomOptsSeparator(t *testing.T) {
+	// CSV-valued opts require a non-comma separator.
+	t.Setenv(buildxDriverEnv, "kubernetes")
+	t.Setenv(buildxDriverOptsSeparatorEnv, ";")
+	t.Setenv(buildxDriverOptsEnvPrefix+"KUBE", "namespace=trdl-build;nodeselector=disktype=ssd,zone=a")
+
+	args, err := buildxCreateArgs("trdl-builder-42")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"buildx", "create",
+		"--name", "trdl-builder-42",
+		"--driver=kubernetes",
+		"--driver-opt=namespace=trdl-build",
+		"--driver-opt=nodeselector=disktype=ssd,zone=a",
+	}, args)
+}
+
+func TestBuildxCreateArgs_MultipleOptVars(t *testing.T) {
+	t.Setenv(buildxDriverEnv, "kubernetes")
+	t.Setenv(buildxDriverOptsSeparatorEnv, "")
+	t.Setenv(buildxDriverOptsEnvPrefix+"ROOTLESS", "rootless=true")
+	t.Setenv(buildxDriverOptsEnvPrefix+"NAMESPACE", " namespace=trdl-build ")
+	t.Setenv(buildxDriverOptsEnvPrefix+"EMPTY", "  ")
+
+	args, err := buildxCreateArgs("trdl-builder-42")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"buildx", "create",
+		"--name", "trdl-builder-42",
+		"--driver=kubernetes",
+		"--driver-opt=namespace=trdl-build",
+		"--driver-opt=rootless=true",
+	}, args)
+}
+
 func TestParseDriverOpts(t *testing.T) {
-	assert.Nil(t, parseDriverOpts(""))
-	assert.Nil(t, parseDriverOpts("\n  \n"))
+	assert.Nil(t, parseDriverOpts("", ","))
+	assert.Nil(t, parseDriverOpts(",  ,", ","))
+	assert.Equal(t,
+		[]string{"namespace=trdl-build", "rootless=true"},
+		parseDriverOpts("  namespace=trdl-build ,, rootless=true ,", ","),
+	)
 	assert.Equal(t,
 		[]string{"namespace=trdl-build", "nodeselector=disktype=ssd,zone=a"},
-		parseDriverOpts("  namespace=trdl-build \n\n nodeselector=disktype=ssd,zone=a \n"),
+		parseDriverOpts("namespace=trdl-build\nnodeselector=disktype=ssd,zone=a", "\n"),
 	)
 }

--- a/server/pkg/docker/builder_test.go
+++ b/server/pkg/docker/builder_test.go
@@ -53,6 +53,16 @@ func TestBuildxCreateArgs_DefaultDriverWithOpts(t *testing.T) {
 	}, args)
 }
 
+func TestBuildxCreateArgs_DriverValueTrimmed(t *testing.T) {
+	t.Setenv(buildxDriverEnv, "  kubernetes  ")
+	t.Setenv(buildxDriverOptsEnv, "")
+
+	args, err := buildxCreateArgs("trdl-builder-42")
+
+	require.NoError(t, err)
+	assert.Contains(t, args, "--driver=kubernetes")
+}
+
 func TestBuildxCreateArgs_UnsupportedDriverRejected(t *testing.T) {
 	t.Setenv(buildxDriverEnv, "docker")
 	t.Setenv(buildxDriverOptsEnv, "")


### PR DESCRIPTION
## Summary

Make the buildx driver used for release builds configurable via environment, so trdl-server can run on Kubernetes-native stands with the buildx `kubernetes` driver instead of requiring a privileged docker-in-docker daemon. Original author: **Vasily Marmer** (authorship preserved on the first two commits).

## Key changes

- `server/pkg/docker/builder.go`: replace the hardcoded `--driver=docker-container` with env knobs:
  - `TRDL_BUILDX_DRIVER` — builder driver, allowlisted to `docker-container` (default) and `kubernetes`; anything else is rejected at builder-create time because the build streams a tarball to stdout (`-o - -`), which the plain `docker` driver cannot export — misconfiguration fails closed instead of opaquely mid-build;
  - `TRDL_BUILDX_DRIVER_OPTS_<ANY_SUFFIX>` — `--driver-opt` values, werf-style: any number of such variables, each carrying one or more values split by a separator, applied in lexicographic variable-name order;
  - `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` — the value separator (`,` by default); a custom separator covers CSV-valued opts such as `nodeselector=disktype=ssd,zone=a` or `tolerations=…`.
- With none of them set, the `docker buildx create` invocation is byte-for-byte identical to the previous hardcoded one, pinned by `TestBuildxCreateArgs_DefaultDriverUnchanged`.
- Unit tests for arg assembly, opt parsing, driver-value trimming, and allowlist rejection (`server/pkg/docker/builder_test.go`).
- Quickstart docs (en/ru): a new "Build backend" administrator section describing the env vars, an example `kubernetes` driver configuration, and the operator prerequisites.
- Opt-in mac-signing e2e suite (`e2e/tests/mac_signing`, `ai_tests` build tag): proves Vault-stored credentials travel through the five buildkit secret mounts into the quill signer stage, the Mach-O detection loop runs, and the signed artifact is re-exported and published. Quill itself is a stub image (`_fixtures/quill_stub`); real `quill sign-and-notarize` still requires Apple credentials.

## Why

trdl currently can only build through a local docker-container builder, which on Kubernetes means running a privileged dind daemon next to Vault — unacceptable on hardened stands. The buildx `kubernetes` driver runs BuildKit as in-cluster pods, but the driver was hardcoded. Env-based configuration matches the existing `TRDL_QUILL_IMAGE` precedent in the same package.

## Review focus / risks

- The `kubernetes` allowlist entry is a promise the driver works end to end. Verified live against kind on darwin/arm64 and linux/amd64: manual probe (rootful and `rootless=true`) with trdl's exact invocation shape — streamed tar context, `--secret` mount readability proven via the exported tar, `buildx rm` teardown clean; plus the full e2e suite with `TRDL_BUILDX_DRIVER=kubernetes` (opts passed via the pre-rework single-variable form; the reworked prefixed form re-verified by a follow-up mac_signing suite run on kind) — all 5 suites green (8 kubernetes-driver builds), including `flow_vault` (real Vault plugin) and `elf_signing` (real delivery-kit-sdk CGO signing; note it is server-side post-build, hence driver-independent by construction).
- Not exercised: real `quill sign-and-notarize` against Apple (stubbed in the new suite); in-cluster ServiceAccount auth — probes authenticated via developer `KUBECONFIG`, production would use a ServiceAccount.
- Operator prerequisites for the `kubernetes` driver (not included here): RBAC for Deployments/Pods in the target namespace, the namespace itself must exist, and rootless BuildKit needs PodSecurity `baseline`, not `restricted`.




