### PR TITLE
fix(server): stop splitting buildx driver opts by default

### DIFF
--- a/docs/pages_en/QUICKSTART.md
+++ b/docs/pages_en/QUICKSTART.md
@@ -29,22 +29,23 @@ During a release, the plugin builds release artifacts with `docker buildx` in an
 On Kubernetes-native installations the build can instead be delegated to in-cluster BuildKit Pods using the buildx `kubernetes` driver. The driver is configured with environment variables of the Vault process:
 
 * `TRDL_BUILDX_DRIVER` — the buildx driver to use: `docker-container` (default) or `kubernetes`;
-* `TRDL_BUILDX_DRIVER_OPTS_<ANY_SUFFIX>` — additional `--driver-opt` values for `docker buildx create`. Any number of such variables can be set; each carries one or more values split by the separator. Values are applied in the lexicographic order of the variable names;
-* `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` — the separator for the values (`,` by default). A custom separator is needed when an option value itself contains commas, e.g. `nodeselector=disktype=ssd,zone=a`.
+* `TRDL_BUILDX_DRIVER_OPTS_<ANY_SUFFIX>` — additional `--driver-opt` values for `docker buildx create`. Any number of such variables can be set, one option each, applied in the lexicographic order of the variable names. The value is passed through as-is, so options containing commas, such as `nodeselector=disktype=ssd,zone=a`, need no escaping;
+* `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` — when set, splits the value of each variable into several options by this separator. Unset by default, meaning one variable carries exactly one option.
 
 An example configuration for the `kubernetes` driver:
 
 ```shell
 TRDL_BUILDX_DRIVER=kubernetes
-TRDL_BUILDX_DRIVER_OPTS_KUBE=namespace=trdl-build,rootless=true
+TRDL_BUILDX_DRIVER_OPTS_NAMESPACE=namespace=trdl-build
+TRDL_BUILDX_DRIVER_OPTS_ROOTLESS=rootless=true
 ```
 
-or the equivalent one-option-per-variable form:
+or the same configuration packed into a single variable with an explicit separator:
 
 ```shell
 TRDL_BUILDX_DRIVER=kubernetes
-TRDL_BUILDX_DRIVER_OPTS_NAMESPACE=namespace=trdl-build
-TRDL_BUILDX_DRIVER_OPTS_ROOTLESS=rootless=true
+TRDL_BUILDX_DRIVER_OPTS_SEPARATOR=;
+TRDL_BUILDX_DRIVER_OPTS_KUBE='namespace=trdl-build;rootless=true'
 ```
 
 Notes on the `kubernetes` driver:

--- a/docs/pages_ru/QUICKSTART.md
+++ b/docs/pages_ru/QUICKSTART.md
@@ -28,22 +28,23 @@ usermod -a -G docker vault
 В Kubernetes-инсталляциях сборку можно делегировать BuildKit-подам внутри кластера, используя buildx-драйвер `kubernetes`. Драйвер настраивается переменными окружения процесса Vault:
 
 * `TRDL_BUILDX_DRIVER` — используемый buildx-драйвер: `docker-container` (по умолчанию) или `kubernetes`;
-* `TRDL_BUILDX_DRIVER_OPTS_<ЛЮБОЙ_СУФФИКС>` — дополнительные значения `--driver-opt` для `docker buildx create`. Таких переменных может быть любое количество; каждая содержит одно или несколько значений, разделённых разделителем. Значения применяются в лексикографическом порядке имён переменных;
-* `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` — разделитель значений (по умолчанию `,`). Пользовательский разделитель нужен, когда само значение опции содержит запятые, например `nodeselector=disktype=ssd,zone=a`.
+* `TRDL_BUILDX_DRIVER_OPTS_<ЛЮБОЙ_СУФФИКС>` — дополнительные значения `--driver-opt` для `docker buildx create`. Таких переменных может быть любое количество, каждая содержит одну опцию; они применяются в лексикографическом порядке имён переменных. Значение передаётся без изменений, поэтому опции с запятыми, например `nodeselector=disktype=ssd,zone=a`, не требуют экранирования;
+* `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` — если задан, значение каждой переменной разделяется на несколько опций по этому разделителю. По умолчанию не задан, то есть одна переменная содержит ровно одну опцию.
 
 Пример конфигурации для драйвера `kubernetes`:
 
 ```shell
 TRDL_BUILDX_DRIVER=kubernetes
-TRDL_BUILDX_DRIVER_OPTS_KUBE=namespace=trdl-build,rootless=true
+TRDL_BUILDX_DRIVER_OPTS_NAMESPACE=namespace=trdl-build
+TRDL_BUILDX_DRIVER_OPTS_ROOTLESS=rootless=true
 ```
 
-или эквивалентная форма «одна опция — одна переменная»:
+или та же конфигурация в одной переменной с явным разделителем:
 
 ```shell
 TRDL_BUILDX_DRIVER=kubernetes
-TRDL_BUILDX_DRIVER_OPTS_NAMESPACE=namespace=trdl-build
-TRDL_BUILDX_DRIVER_OPTS_ROOTLESS=rootless=true
+TRDL_BUILDX_DRIVER_OPTS_SEPARATOR=;
+TRDL_BUILDX_DRIVER_OPTS_KUBE='namespace=trdl-build;rootless=true'
 ```
 
 Особенности драйвера `kubernetes`:

--- a/server/pkg/docker/builder.go
+++ b/server/pkg/docker/builder.go
@@ -21,20 +21,19 @@ import (
 
 const (
 	buildxDriverEnv = "TRDL_BUILDX_DRIVER"
-	// Every TRDL_BUILDX_DRIVER_OPTS_<SUFFIX> variable carries `--driver-opt`
-	// values split by the separator, e.g. TRDL_BUILDX_DRIVER_OPTS_KUBE="namespace=trdl-build,rootless=true".
+	// Every TRDL_BUILDX_DRIVER_OPTS_<SUFFIX> variable carries one `--driver-opt`,
+	// e.g. TRDL_BUILDX_DRIVER_OPTS_NAMESPACE="namespace=trdl-build", or several
+	// when TRDL_BUILDX_DRIVER_OPTS_SEPARATOR is set.
 	buildxDriverOptsEnvPrefix    = "TRDL_BUILDX_DRIVER_OPTS_"
 	buildxDriverOptsSeparatorEnv = "TRDL_BUILDX_DRIVER_OPTS_SEPARATOR"
 
-	defaultBuildxDriver              = "docker-container"
-	defaultBuildxDriverOptsSeparator = ","
+	defaultBuildxDriver = "docker-container"
 )
 
-// supportedBuildxDrivers are the drivers trdl will create a builder for. The
-// build streams a tarball to stdout (`-o - -`), which the default "docker"
-// driver cannot export; only full-BuildKit drivers are accepted, so an
-// unsupported driver fails closed here with a clear error rather than later with
-// an opaque build failure.
+// supportedBuildxDrivers are the drivers trdl has verified. The build streams a
+// tarball to stdout (`-o - -`), which the default "docker" driver cannot export,
+// so an unsupported driver fails closed here with a clear error rather than
+// later with an opaque build failure.
 var supportedBuildxDrivers = []string{"docker-container", "kubernetes"}
 
 type Logger interface {
@@ -103,30 +102,35 @@ func buildxCreateArgs(builderName string) ([]string, error) {
 }
 
 func driverOptsFromEnv() []string {
-	separator := os.Getenv(buildxDriverOptsSeparatorEnv)
-	if separator == "" {
-		separator = defaultBuildxDriverOptsSeparator
+	var names []string
+	for _, keyValue := range os.Environ() {
+		name, _, _ := strings.Cut(keyValue, "=")
+		if strings.HasPrefix(name, buildxDriverOptsEnvPrefix) && name != buildxDriverOptsSeparatorEnv {
+			names = append(names, name)
+		}
 	}
+	sort.Strings(names)
+
+	separator := os.Getenv(buildxDriverOptsSeparatorEnv)
 
 	var opts []string
-	env := os.Environ()
-	sort.Strings(env)
-	for _, keyValue := range env {
-		name, value, _ := strings.Cut(keyValue, "=")
-		if !strings.HasPrefix(name, buildxDriverOptsEnvPrefix) || name == buildxDriverOptsSeparatorEnv {
-			continue
-		}
-		opts = append(opts, parseDriverOpts(value, separator)...)
+	for _, name := range names {
+		opts = append(opts, parseDriverOpts(os.Getenv(name), separator)...)
 	}
 
 	return opts
 }
 
-// CSV-valued opts such as nodeselector/tolerations need a custom separator or
-// the one-opt-per-variable form to survive the comma-separated default.
+// An empty separator passes the value through untouched, so comma-valued opts
+// such as nodeselector/tolerations survive without escaping.
 func parseDriverOpts(raw, separator string) []string {
+	parts := []string{raw}
+	if separator != "" {
+		parts = strings.Split(raw, separator)
+	}
+
 	var opts []string
-	for _, part := range strings.Split(raw, separator) {
+	for _, part := range parts {
 		if v := strings.TrimSpace(part); v != "" {
 			opts = append(opts, v)
 		}

--- a/server/pkg/docker/builder_test.go
+++ b/server/pkg/docker/builder_test.go
@@ -1,13 +1,26 @@
 package docker
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// driverOptsFromEnv reads the ambient environment, so an operator-set
+// TRDL_BUILDX_DRIVER_OPTS_* would otherwise leak into every expectation.
+func clearDriverOptsEnv(t *testing.T) {
+	for _, keyValue := range os.Environ() {
+		if name, _, _ := strings.Cut(keyValue, "="); strings.HasPrefix(name, buildxDriverOptsEnvPrefix) {
+			t.Setenv(name, "")
+		}
+	}
+}
+
 func TestBuildxCreateArgs_DefaultDriverUnchanged(t *testing.T) {
+	clearDriverOptsEnv(t)
 	t.Setenv(buildxDriverEnv, "")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
@@ -21,8 +34,10 @@ func TestBuildxCreateArgs_DefaultDriverUnchanged(t *testing.T) {
 }
 
 func TestBuildxCreateArgs_KubernetesDriverWithOpts(t *testing.T) {
+	clearDriverOptsEnv(t)
 	t.Setenv(buildxDriverEnv, "kubernetes")
-	t.Setenv(buildxDriverOptsEnvPrefix+"KUBE", "namespace=trdl-build,rootless=true")
+	t.Setenv(buildxDriverOptsEnvPrefix+"NAMESPACE", "namespace=trdl-build")
+	t.Setenv(buildxDriverOptsEnvPrefix+"ROOTLESS", "rootless=true")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
@@ -37,8 +52,10 @@ func TestBuildxCreateArgs_KubernetesDriverWithOpts(t *testing.T) {
 }
 
 func TestBuildxCreateArgs_DefaultDriverWithOpts(t *testing.T) {
+	clearDriverOptsEnv(t)
 	t.Setenv(buildxDriverEnv, "")
-	t.Setenv(buildxDriverOptsEnvPrefix+"CONTAINER", "image=moby/buildkit:v0.12.0,network=host")
+	t.Setenv(buildxDriverOptsEnvPrefix+"IMAGE", "image=moby/buildkit:v0.12.0")
+	t.Setenv(buildxDriverOptsEnvPrefix+"NETWORK", "network=host")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
 
@@ -53,6 +70,7 @@ func TestBuildxCreateArgs_DefaultDriverWithOpts(t *testing.T) {
 }
 
 func TestBuildxCreateArgs_DriverValueTrimmed(t *testing.T) {
+	clearDriverOptsEnv(t)
 	t.Setenv(buildxDriverEnv, "  kubernetes  ")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
@@ -62,6 +80,7 @@ func TestBuildxCreateArgs_DriverValueTrimmed(t *testing.T) {
 }
 
 func TestBuildxCreateArgs_UnsupportedDriverRejected(t *testing.T) {
+	clearDriverOptsEnv(t)
 	t.Setenv(buildxDriverEnv, "docker")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
@@ -72,8 +91,24 @@ func TestBuildxCreateArgs_UnsupportedDriverRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), buildxDriverEnv)
 }
 
+func TestBuildxCreateArgs_CommaValuePassedThroughWithoutSeparator(t *testing.T) {
+	clearDriverOptsEnv(t)
+	t.Setenv(buildxDriverEnv, "kubernetes")
+	t.Setenv(buildxDriverOptsEnvPrefix+"NODESELECTOR", "nodeselector=disktype=ssd,zone=a")
+
+	args, err := buildxCreateArgs("trdl-builder-42")
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{
+		"buildx", "create",
+		"--name", "trdl-builder-42",
+		"--driver=kubernetes",
+		"--driver-opt=nodeselector=disktype=ssd,zone=a",
+	}, args)
+}
+
 func TestBuildxCreateArgs_CustomOptsSeparator(t *testing.T) {
-	// CSV-valued opts require a non-comma separator.
+	clearDriverOptsEnv(t)
 	t.Setenv(buildxDriverEnv, "kubernetes")
 	t.Setenv(buildxDriverOptsSeparatorEnv, ";")
 	t.Setenv(buildxDriverOptsEnvPrefix+"KUBE", "namespace=trdl-build;nodeselector=disktype=ssd,zone=a")
@@ -90,11 +125,11 @@ func TestBuildxCreateArgs_CustomOptsSeparator(t *testing.T) {
 	}, args)
 }
 
-func TestBuildxCreateArgs_MultipleOptVars(t *testing.T) {
+func TestBuildxCreateArgs_OptsOrderedByVariableName(t *testing.T) {
+	clearDriverOptsEnv(t)
 	t.Setenv(buildxDriverEnv, "kubernetes")
-	t.Setenv(buildxDriverOptsSeparatorEnv, "")
-	t.Setenv(buildxDriverOptsEnvPrefix+"ROOTLESS", "rootless=true")
-	t.Setenv(buildxDriverOptsEnvPrefix+"NAMESPACE", " namespace=trdl-build ")
+	t.Setenv(buildxDriverOptsEnvPrefix+"A1", "second=2")
+	t.Setenv(buildxDriverOptsEnvPrefix+"A", "first=1")
 	t.Setenv(buildxDriverOptsEnvPrefix+"EMPTY", "  ")
 
 	args, err := buildxCreateArgs("trdl-builder-42")
@@ -104,20 +139,21 @@ func TestBuildxCreateArgs_MultipleOptVars(t *testing.T) {
 		"buildx", "create",
 		"--name", "trdl-builder-42",
 		"--driver=kubernetes",
-		"--driver-opt=namespace=trdl-build",
-		"--driver-opt=rootless=true",
+		"--driver-opt=first=1",
+		"--driver-opt=second=2",
 	}, args)
 }
 
 func TestParseDriverOpts(t *testing.T) {
-	assert.Nil(t, parseDriverOpts("", ","))
+	assert.Nil(t, parseDriverOpts("", ""))
+	assert.Nil(t, parseDriverOpts("  ", ""))
+	assert.Equal(t,
+		[]string{"nodeselector=disktype=ssd,zone=a"},
+		parseDriverOpts(" nodeselector=disktype=ssd,zone=a ", ""),
+	)
 	assert.Nil(t, parseDriverOpts(",  ,", ","))
 	assert.Equal(t,
 		[]string{"namespace=trdl-build", "rootless=true"},
 		parseDriverOpts("  namespace=trdl-build ,, rootless=true ,", ","),
-	)
-	assert.Equal(t,
-		[]string{"namespace=trdl-build", "nodeselector=disktype=ssd,zone=a"},
-		parseDriverOpts("namespace=trdl-build\nnodeselector=disktype=ssd,zone=a", "\n"),
 	)
 }


### PR DESCRIPTION
## Summary

Follow-up to #398. Make buildx `--driver-opt` splitting opt-in, so an option value that legitimately contains commas is no longer silently torn apart, and apply the options in the documented variable-name order. The env-configurable driver itself is unchanged — this is not a revert of #398.

## Key changes

- `server/pkg/docker/builder.go`:
  - `parseDriverOpts` no longer splits when `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` is unset — the value is passed through as a single option, so `nodeselector=disktype=ssd,zone=a` survives without escaping. Splitting became opt-in via an explicit separator, and `defaultBuildxDriverOptsSeparator` is gone;
  - `driverOptsFromEnv` sorts variable *names* rather than whole `NAME=VALUE` entries;
  - the `supportedBuildxDrivers` comment no longer claims that only full-BuildKit drivers are accepted — `remote` is full BuildKit and can export to stdout, yet is deliberately not on the list. It now says these are the drivers trdl has verified.
- `server/pkg/docker/builder_test.go`:
  - regression tests `TestBuildxCreateArgs_CommaValuePassedThroughWithoutSeparator` and `TestBuildxCreateArgs_OptsOrderedByVariableName`;
  - `clearDriverOptsEnv` helper strips ambient `TRDL_BUILDX_DRIVER_OPTS_*` so the expectations are hermetic;
  - `TestParseDriverOpts` covers both the passthrough and the explicit-separator mode.
- `docs/pages_en/QUICKSTART.md`, `docs/pages_ru/QUICKSTART.md`: document the passthrough default, note that comma-containing values need no escaping, and present the separator as the opt-in for packing several options into one variable.

## Why

`TRDL_BUILDX_DRIVER_OPTS_*` values were always split, with the separator defaulting to a comma:

```
TRDL_BUILDX_DRIVER_OPTS_NODESELECTOR=nodeselector=disktype=ssd,zone=a
→ --driver-opt=nodeselector=disktype=ssd  --driver-opt=zone=a
```

This happened even in the one-option-per-variable form that #398's docs presented as equivalent, and `nodeselector=disktype=ssd,zone=a` was the docs' own motivating example. The builder then either failed opaquely or got scheduled onto the wrong nodes — a silent misconfiguration in release infrastructure, which is the worst failure mode available here.

The ordering bug has the same root: sorting `NAME=VALUE` strings instead of names. Since `=` (0x3D) sorts above digits (0x30–0x39), `TRDL_BUILDX_DRIVER_OPTS_A1` was applied before `TRDL_BUILDX_DRIVER_OPTS_A`, contradicting the lexicographic variable-name order the docs promise.

## Review focus / risks

- **The default changes, but nothing breaks.** `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` has never shipped in a release: the latest tag is `v0.12.3`, #398 is contained in no tag, and `release-v0.13.0` (#393) is still open. No installation can depend on the old comma default.
- **Both regressions are falsifiable**, verified by mutation — reintroducing either bug fails exactly its own test and nothing else:

  | Mutation | `CommaValuePassedThrough…` | `OptsOrderedByVariableName` |
  |---|---|---|
  | restore default `,` splitting | **FAIL** | PASS |
  | restore `sort.Strings(env)` over `NAME=VALUE` | PASS | **FAIL** |

- **`TRDL_BUILDX_DRIVER_OPTS_SEPARATOR` still lives inside the `TRDL_BUILDX_DRIVER_OPTS_` namespace it configures**, and is silently excluded from the option scan. So `TRDL_BUILDX_DRIVER_OPTS_SEPARATOR=namespace=trdl-build` is dropped without a warning. Kept deliberately: with the passthrough default the separator is rarely needed, hence the collision is rare too.