### PR TITLE
test(e2e, ci): cover the buildx kubernetes driver and unskip mac signing

### DIFF
--- a/.github/workflows/tests_buildx_kubernetes_driver.yaml
+++ b/.github/workflows/tests_buildx_kubernetes_driver.yaml
@@ -1,0 +1,82 @@
+name: Tests. Buildx kubernetes driver
+
+# Opt-in: the buildx kubernetes driver needs a cluster, so this is not part of
+# the required checks. It runs the flow_vault suite — the real Vault plugin,
+# a real release build and buildkit secret mounts — against in-cluster BuildKit
+# pods instead of the default docker-container builder.
+on:
+  workflow_dispatch:
+
+env:
+  TASK_X_REMOTE_TASKFILES: 1
+  KIND_VERSION: v0.32.0
+
+jobs:
+  e2e_tests_buildx_kubernetes:
+    name: End-to-end tests (buildx kubernetes driver)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    env:
+      TRDL_BUILDX_DRIVER: kubernetes
+      TRDL_BUILDX_DRIVER_OPTS_NAMESPACE: namespace=default
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: e2e/go.mod
+
+      - name: Install Task
+        uses: go-task/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up prebuilt trdl test binary
+        run: |
+          task --yes client:build-with-coverage
+          echo TRDL_TEST_BINARY_PATH=$GITHUB_WORKSPACE/bin/coverage/trdl >> $GITHUB_ENV
+          echo TRDL_TEST_COVERAGE_DIR=$GITHUB_WORKSPACE/tests_coverage/e2e >> $GITHUB_ENV
+
+      - name: Set up git config
+        run: task --yes ci:setup:git-config
+
+      - name: Prepare environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gpg
+          task --yes server:deps:install:c
+
+      - name: Install 3p-git-signatures
+        run: task --yes ci:install:3p-git-signatures
+
+      - name: Install ginkgo
+        run: task --yes -p deps:install:ginkgo
+
+      - name: Setup vault
+        run: |
+          task --yes server:setup-vault-local
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Set up kind cluster
+        run: |
+          curl -fsSLo /tmp/kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64
+          sudo install -m 0755 /tmp/kind /usr/local/bin/kind
+          kind create cluster --name trdl-buildx
+          kubectl cluster-info --context kind-trdl-buildx
+
+      - name: Test
+        run: task --yes e2e:test:e2e:flow-vault
+
+      - name: Collect builder diagnostics
+        if: failure()
+        run: |
+          kubectl get pods,deployments --all-namespaces || true
+          docker buildx ls || true
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e_coverage_buildx_kubernetes
+          path: tests_coverage

--- a/e2e/Taskfile.yaml
+++ b/e2e/Taskfile.yaml
@@ -26,3 +26,15 @@ tasks:
     cmd: ginkgo --vv --keep-going --cover --covermode=atomic --coverpkg=github.com/werf/trdl/client/...,github.com/werf/trdl/server/... --output-dir={{.outputDir}} ./tests/elf_signing
     vars:
       outputDir: '{{.outputDir | default "../tests_coverage/e2e" }}'
+
+  test:e2e:flow-vault:
+    desc: "Run the Vault plugin e2e test. Honours TRDL_BUILDX_DRIVER, so it doubles as the buildx driver check."
+    cmd: ginkgo --vv --keep-going --cover --covermode=atomic --coverpkg=github.com/werf/trdl/client/...,github.com/werf/trdl/server/... --output-dir={{.outputDir}} ./tests/flow_vault
+    vars:
+      outputDir: '{{.outputDir | default "../tests_coverage/e2e" }}'
+
+  test:e2e:mac-signing:
+    desc: "Run mac signing e2e test against a stub quill (ai_tests tag, excluded from the default run)."
+    cmd: ginkgo --vv --keep-going --tags=ai_tests --cover --covermode=atomic --coverpkg=github.com/werf/trdl/client/...,github.com/werf/trdl/server/... --output-dir={{.outputDir}} ./tests/mac_signing
+    vars:
+      outputDir: '{{.outputDir | default "../tests_coverage/e2e" }}'

--- a/e2e/tests/mac_signing/_fixtures/complete_cycle/docker-compose.yaml
+++ b/e2e/tests/mac_signing/_fixtures/complete_cycle/docker-compose.yaml
@@ -18,3 +18,12 @@ services:
       MC_HOST_main: http://minioadmin:minioadmin@minio:9000
     networks:
       - minio-net
+
+  # Serves the quill stub to the buildkit builder, which cannot see images from
+  # the local docker daemon. The host port is fixed rather than random because
+  # Docker Desktop does not forward the ephemeral range into its VM, so the
+  # daemon there could not push to it.
+  registry:
+    image: registry@sha256:a3d8aaa63ed8681a604f1dea0aa03f100d5895b6a58ace528858a7b332415373
+    ports:
+      - "127.0.0.1:5555:5000"

--- a/e2e/tests/mac_signing/complete_cycle_ai_test.go
+++ b/e2e/tests/mac_signing/complete_cycle_ai_test.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -23,13 +22,13 @@ import (
 )
 
 // The suite proves trdl's mac-signing plumbing end to end without Apple
-// credentials: TRDL_QUILL_IMAGE must point at a stub image (built from
-// _fixtures/quill_stub) whose quill validates the five QUILL_* env vars and
-// appends a marker with the received cert and notary key id to the artifact.
-// Asserting the marker in the published artifact proves the Vault-stored
-// credential values travelled through the buildkit secret mounts into the
-// signer stage, the Mach-O detection loop ran, and the "signed" artifact was
-// re-exported through the final scratch stage.
+// credentials. It builds _fixtures/quill_stub and serves it from a throwaway
+// registry; that quill validates the five QUILL_* env vars and appends a marker
+// with the received cert and notary key id to the artifact. Asserting the marker
+// in the published artifact proves the Vault-stored credential values travelled
+// through the buildkit secret mounts into the signer stage, the Mach-O detection
+// loop ran, and the "signed" artifact was re-exported through the final scratch
+// stage.
 var _ = Describe("Mac signing", func() {
 	var storage logical.Storage
 	var backend *server.Backend
@@ -64,10 +63,6 @@ var _ = Describe("Mac signing", func() {
 	}
 
 	BeforeEach(func() {
-		if os.Getenv("TRDL_QUILL_IMAGE") == "" {
-			Skip("TRDL_QUILL_IMAGE is not set; build and push _fixtures/quill_stub to a registry reachable by the buildkit builder and point TRDL_QUILL_IMAGE at it")
-		}
-
 		testutil.RunSucceedCommand(
 			testutil.FixturePath("pgp_keys"),
 			"gpg",
@@ -95,8 +90,18 @@ var _ = Describe("Mac signing", func() {
 		testutil.RunSucceedCommand(testDir, "docker", "compose", "run", "mc", "mb", "main/repo")
 		testutil.RunSucceedCommand(testDir, "docker", "compose", "run", "mc", "policy", "set", "download", "main/repo")
 
-		output := testutil.SucceedCommandOutputString(testDir, "docker", "compose", "port", "minio", "9000")
-		minioAddress = "http://" + strings.TrimSpace(output)
+		minioAddress = "http://127.0.0.1:" + composePort("minio", "9000")
+
+		// The builder runs buildkit in its own container and cannot see images from
+		// the local docker daemon, so the stub is served over a registry. Only a
+		// loopback address is treated as insecure by default, and only network=host
+		// lets the builder reach it.
+		quillImage := "127.0.0.1:" + composePort("registry", "5000") + "/quill-stub:latest"
+		testutil.RunSucceedCommand(testutil.FixturePath("quill_stub"), "docker", "build", "--tag", quillImage, ".")
+		testutil.RunSucceedCommand(testutil.FixturePath("quill_stub"), "docker", "push", quillImage)
+
+		setEnv("TRDL_QUILL_IMAGE", quillImage)
+		setEnv("TRDL_BUILDX_DRIVER_OPTS_NETWORK", "network=host")
 	})
 
 	AfterEach(func() {

--- a/e2e/tests/mac_signing/helpers_ai_test.go
+++ b/e2e/tests/mac_signing/helpers_ai_test.go
@@ -1,0 +1,33 @@
+//go:build ai_tests
+// +build ai_tests
+
+package mac_signing
+
+import (
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/werf/trdl/server/pkg/testutil"
+)
+
+func composePort(service, containerPort string) string {
+	hostPort := testutil.SucceedCommandOutputString(testDir, "docker", "compose", "port", service, containerPort)
+
+	return strings.TrimSpace(hostPort[strings.LastIndex(hostPort, ":")+1:])
+}
+
+func setEnv(name, value string) {
+	previous, existed := os.LookupEnv(name)
+	Expect(os.Setenv(name, value)).To(Succeed())
+
+	DeferCleanup(func() {
+		if !existed {
+			Expect(os.Unsetenv(name)).To(Succeed())
+			return
+		}
+		Expect(os.Setenv(name, previous)).To(Succeed())
+	})
+}


### PR DESCRIPTION
## Summary

Closes the two follow-ups left open by #398 and #399: the `mac_signing` e2e suite now runs with a single command instead of skipping, and the buildx `kubernetes` driver gets its first automated coverage through an opt-in CI job. No production code changes.

## Key changes

- `e2e/tests/mac_signing`:
  - the suite builds `_fixtures/quill_stub` itself and serves it from a `registry` service added to the suite's compose stack, so the `Skip` on an unset `TRDL_QUILL_IMAGE` is gone;
  - the builder is pointed at that registry with `TRDL_BUILDX_DRIVER_OPTS_NETWORK=network=host`, because buildkit runs in its own container and cannot see images from the local docker daemon;
  - `helpers_ai_test.go` adds `composePort` and `setEnv` (the latter restores the previous value via `DeferCleanup`);
  - the registry host port is fixed rather than random — Docker Desktop does not forward the ephemeral range into its VM, so the daemon there cannot push to a randomly published port.
- `e2e/Taskfile.yaml`: `test:e2e:mac-signing` (carries `--tags=ai_tests`, so it stays out of the default run) and `test:e2e:flow-vault`.
- `.github/workflows/tests_buildx_kubernetes_driver.yaml`: `workflow_dispatch` job that creates a kind cluster and runs the `flow_vault` suite with `TRDL_BUILDX_DRIVER=kubernetes`, plus a `if: failure()` step dumping pods and `buildx ls`.

## Why

Two gaps from the buildx-driver work were explicitly deferred:

**The `mac_signing` suite produced no evidence in any pipeline.** It skipped unless an operator had manually built and pushed the stub image to a registry the builder could reach, so in practice it never ran. It stays behind the `ai_tests` tag, as `AGENTS.md` requires for AI-authored tests — that part is by design, not a defect.

**The `kubernetes` driver had no automated coverage.** The unit tests in #398/#399 only pin `[]string` assembly and would stay green if the driver were broken end to end; the allowlist entry rested entirely on manual verification described in prose. `flow_vault` is the right vehicle: it drives the real Vault plugin, a real release build, and buildkit `--secret` mounts.

As a side effect the mac-signing suite becomes the first automated coverage of the `TRDL_BUILDX_DRIVER_OPTS_*` mechanism itself — it now depends on a driver opt reaching `docker buildx create`.

## Review focus / risks

- **The mac-signing suite is verified green locally** (`task e2e:test:e2e:mac-signing`, darwin/arm64, 1 Passed) — the first passing run of this suite. Its coverage is falsifiable: removing the `TRDL_BUILDX_DRIVER_OPTS_NETWORK` line makes it fail, which is what proves the driver opt actually reaches buildx.
- **The kubernetes-driver job is verified green in CI** ([run 30361575186](https://github.com/werf/trdl/actions/runs/30361575186)), exercised from this branch with a temporary `push` trigger that has since been removed. The run log carries the proof that the driver was actually used rather than silently falling back: `#1 waiting for 1 pods to be ready` is kubernetes-driver output, and `namespace=default` shows the driver opt arriving. The first attempt failed on a missing `TASK_X_REMOTE_TASKFILES`, which is why the check was worth running before merge.
- **The suite itself cannot be run locally** — — `flow_vault` builds the Vault plugin, and `linux_syscall.c` does not compile on darwin. What I did verify on kind (darwin/arm64) is the driver in trdl's exact invocation shape: `buildx create --driver=kubernetes --driver-opt=namespace=default`, a tar context streamed over stdin, `--secret id=…` asserted readable inside the build, and `-o - -` exporting the artifact back. So the mechanics hold; the job wiring itself gets its first real exercise when someone dispatches it.
- **New tool in CI, flagged per `AGENTS.md`:** the job downloads the kind release binary (pinned `v0.32.0`). I avoided `helm/kind-action` specifically because it would add a third-party action to a repo that currently uses only `actions/*`, `go-task/setup-task`, `mattermost/action-mattermost-notify` and `werf/third-party-release-please-action`.
- **Fixed host port 5555** for the suite registry is a deliberate ceiling: it collides if something else holds the port, and compose then fails loudly. A random port is not an option on Docker Desktop (see above).
- `actions:lint` fails locally on this machine for an unrelated npm/node reason — reproduced on a clean `main`. The new workflow was checked with the same prettier image the task uses (`tmknom/prettier:3.5.3`): clean.
