### PR TITLE
fix: point trdl.yaml at the builder image rebuilt on Go 1.25.12

### DIFF
--- a/client/trdl.yaml
+++ b/client/trdl.yaml
@@ -1,4 +1,4 @@
-docker_image: registry.werf.io/trdl/builder:d340e2a5a1d0447772f3045da0ae87c6fa5239ee@sha256:21ef0e721c02c9777b0e6a4807d5a1b21a36048e9ae16c3af5023b8fb98eb7c3
+docker_image: registry.werf.io/trdl/builder:0c698d20c333bae5dc96328d41805e017cd6d086@sha256:9b1a9ed35e7f378e0471659a949753f8bac9de7cedf77f62ca8e54190be23e2d
 commands:
   - TASK_X_REMOTE_TASKFILES=1 task --yes client:build:dist version={{ .Tag }}
   - TASK_X_REMOTE_TASKFILES=1 task --yes client:verify:dist:binaries version={{ .Tag }}

--- a/release/trdl.yaml
+++ b/release/trdl.yaml
@@ -1,4 +1,4 @@
-dockerImage: registry.werf.io/trdl/builder:d340e2a5a1d0447772f3045da0ae87c6fa5239ee@sha256:21ef0e721c02c9777b0e6a4807d5a1b21a36048e9ae16c3af5023b8fb98eb7c3
+dockerImage: registry.werf.io/trdl/builder:0c698d20c333bae5dc96328d41805e017cd6d086@sha256:9b1a9ed35e7f378e0471659a949753f8bac9de7cedf77f62ca8e54190be23e2d
 commands:
   - TASK_X_REMOTE_TASKFILES=1 task --yes release:build:dist version={{ .Tag }}
   - TASK_X_REMOTE_TASKFILES=1 task --yes release:verify:dist:binaries version={{ .Tag }}

--- a/server/trdl.yaml
+++ b/server/trdl.yaml
@@ -1,4 +1,4 @@
-dockerImage: registry.werf.io/trdl/builder:d340e2a5a1d0447772f3045da0ae87c6fa5239ee@sha256:21ef0e721c02c9777b0e6a4807d5a1b21a36048e9ae16c3af5023b8fb98eb7c3
+dockerImage: registry.werf.io/trdl/builder:0c698d20c333bae5dc96328d41805e017cd6d086@sha256:9b1a9ed35e7f378e0471659a949753f8bac9de7cedf77f62ca8e54190be23e2d
 commands:
   - TASK_X_REMOTE_TASKFILES=1 task --yes server:build:dist version={{ .Tag }}
   - TASK_X_REMOTE_TASKFILES=1 task --yes server:verify:dist:binaries version={{ .Tag }}


### PR DESCRIPTION
Follow-up to #402, which was merged one commit early.

#402 raised every module to `go 1.25.0` and moved `trdl-builder.Dockerfile` to `golang:1.25.12-bookworm`, but the commit repinning the manifests was pushed after the merge and did not land. Right now `main` is inconsistent:

```
$ git show main:server/go.mod | grep '^go '
go 1.25.0
$ git show main:server/trdl.yaml | head -1
dockerImage: registry.werf.io/trdl/builder:d340e2a5...   # built FROM golang:1.24-bookworm
```

A release cut from `main` would run `task server:build:dist` inside a Go 1.24 builder against modules requiring `go >= 1.25.0` and fail with `module requires go >= 1.25.0` — the exact breakage #402 set out to fix.

## The image

`registry.werf.io/trdl/builder:0c698d20c333bae5dc96328d41805e017cd6d086@sha256:9b1a9ed3...` — published from the head of #402's branch, where the Dockerfile moves to `golang:1.25.12-bookworm`.

Its tree is byte-identical to what was squashed onto main, so the image content is exactly what landed:

```
$ git diff --stat 0c698d2 main
(empty)
```

Verified inside the image: `go version go1.25.12 linux/amd64`, `Task version: v3.33.1`, `file-5.44`, `git 2.39.5`.

Note the tag names a commit that no longer exists on main, since #402 was squash-merged — same as the previous pin, which named `d340e2a5`, a commit unrelated to the Dockerfile. The digest is what pins the content.

Building this image is also a real check on #402: the Dockerfile runs `task build:dist:all` plus `client:verify:dist:binaries` and `server:verify:dist:binaries`, so producing it cross-compiled every component for all five target platforms on Go 1.25.12 and verified the resulting binaries.

`client/trdl.yaml` keeps its `docker_image` key while the other two keep `dockerImage`; left as-is, unrelated to this change.
