### PR TITLE
chore(dev): add agent skills harness mirroring werf/werf

### DIFF
--- a/.agents/skills/agent-code-review/SKILL.md
+++ b/.agents/skills/agent-code-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: agent-code-review
+description: >
+  Adversarial verification layer for reviewing agent-generated or otherwise untrusted
+  implementations. Use when the author of a diff, patch, commit, or test suite is an agent,
+  when a change touches tests or verification infrastructure, or when invoked as
+  /agent-code-review. Adds test falsifiability checks and check-gaming detection on top of
+  ordinary review; does not replace it.
+---
+
+# Agent Code Review
+
+Treat the change as an untrusted implementation candidate. Readable code, passing tests,
+high coverage, and the author's confidence are not evidence of correctness. Coverage
+percentage is not evidence by itself.
+
+Do not ask only:
+
+> Does this code look correct?
+
+Also ask:
+
+> What evidence would fail if this implementation were wrong?
+
+## Recover the contract first
+
+Identify intended behavior, acceptance criteria, and behavior that must remain unchanged.
+If the intended behavior is unclear, that is the first finding.
+
+Do not invent a stronger contract than the task provides. A finding against a requirement
+the task never stated is noise.
+
+## Test the tests
+
+Invoke the `test-the-tests` skill for this step: verify each test that carries weight by
+actually mutating the implementation (invert a condition, remove validation, suppress an
+error, skip a side effect, revert to the prior behavior) and confirming the test fails.
+A suite that cannot detect a plausible fault is weak even when it passes — passing and
+high coverage are not evidence by themselves.
+
+## Check-gaming
+
+Flag changes that:
+
+- weaken or delete assertions;
+- update golden files without explaining the behavioral change;
+- skip, quarantine, or filter tests;
+- lower quality thresholds;
+- add test-only branches or detect CI/test environments;
+- hardcode fixture-specific answers;
+- rely entirely on mocks for critical behavior;
+- modify verification scripts together with the implementation;
+- present logs or reports without proving they belong to the reviewed commit.
+
+Unexplained changes to tests or verification infrastructure are high risk by default.
+
+## Inspection depth
+
+Direct inspection of the implementation is mandatory regardless of green checks when the
+change touches auth, secrets, crypto, billing, data deletion, migrations, concurrency,
+release or supply-chain logic, public APIs, persistent formats, or anything hard to roll
+back.
+
+For low-risk mechanical changes with strong evidence, targeted inspection is enough. No
+line-by-line narration in either case.
+
+## Know this review's limits when you are the author
+
+If you wrote the diff you are now reviewing, this pass is necessary but not sufficient.
+Self-review — even done adversarially, even by mutating your own tests — inherits your own
+design assumptions; it reliably catches localized bugs and weak tests, but is a poor
+substitute for a second opinion on whether the overall approach or architecture is sound.
+An independently-invoked reviewer with no memory of your rationale (a fresh subagent, or an
+external tool/model such as Codex) will more reliably surface issues you can't see because
+you already believe your own premises.
+
+For anything more than a mechanical or low-risk change, escalate to an independently
+invoked reviewer before merging — don't treat your own adversarial pass as the final word.
+Say so explicitly in your findings when you are the diff's author and no second reviewer
+has looked yet, so the person deciding whether to merge knows that gap exists.
+
+## Output
+
+Report only actionable findings. Each one: where the problem is visible, what fails and
+under which conditions, and the smallest concrete correction or missing proof. Style
+preferences are not defects.
+
+Passing checks are claims. The review's job is to establish whether those checks are
+capable of disproving the implementation.

--- a/.agents/skills/git-conventions/SKILL.md
+++ b/.agents/skills/git-conventions/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: git-conventions
+description: Git workflow conventions for commits, branches, and pull requests. Load this skill when creating commits, branches, or PRs.
+---
+
+## Git Conventions
+
+Load this skill when creating commits, naming branches, or opening pull requests.
+
+### Commit Message
+
+```
+<type>(<scope>): <subject>
+<BLANK LINE>
+<body>
+```
+
+#### Type
+
+| Type | Purpose |
+|------|---------|
+| **feat** | New features or capabilities that enhance the user's experience |
+| **fix** | Bug fixes that enhance the user's experience |
+| **refactor** | Code changes that neither fix a bug nor add a feature |
+| **docs** | Updates or improvements to documentation |
+| **test** | Additions or corrections to tests |
+| **chore** | Updates that don't fit into other types |
+
+#### Scope
+
+Scope identifies the area of the project affected by the change. It is context-dependent and derived from the project structure. Common top-level scopes for maintaining code quality and development workflow:
+
+- **ci** — CI/CD pipeline
+- **release** — release process
+- **dev** — development workflow
+- **deps** — dependencies
+
+#### Subject
+
+- Imperative, present tense: "change" not "changed" nor "changes"
+- Don't capitalize the first letter
+- No dot (.) at the end
+
+#### Body
+
+- Imperative, present tense (same as subject)
+- Include the motivation for the change and contrast with previous behavior
+
+### Branch Name
+
+```
+<type>/<scope>/<short-description>
+```
+
+- Use only the **top-level scope** (no nested/multiple scopes)
+- `<short-description>` is kebab-case, concise, hyphen-separated
+
+Examples:
+```
+feat/api/add-user-endpoint
+fix/auth/token-refresh
+refactor/core/simplify-parser
+```
+
+### Pull Requests
+
+See the `pull-request` skill for PR title and description conventions (draft by default, `<type>(<scope>): <subject>` title mirroring the main commit, mandatory Summary / Key changes / Why / Review focus structure).
+
+### Before pushing
+
+- ALWAYS check the current branch (`git branch --show-current`) before pushing — don't assume it matches what you intend to push. A repo can have a stale local `main` far behind `origin/main`, or you can be checked out on someone else's WIP topic branch without noticing.
+- NEVER push directly to a shared/team repo's default branch (one you don't solely own — e.g. an open-source project, a company repo with other contributors). Branch from the current `origin/<default>` and open a PR instead, even for a small or "obviously safe" change.
+- If a push is rejected as non-fast-forward, don't force it — fetch and figure out why the ref diverged (stale local branch, someone else's history, wrong ref name) before deciding how to proceed.

--- a/.agents/skills/pull-request/SKILL.md
+++ b/.agents/skills/pull-request/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: pull-request
+description: Formats Pull Request titles and descriptions according to project conventions. Use when creating or updating a PR.
+---
+
+# Pull Request Conventions
+
+## Defaults
+
+- Always create PRs as draft (`gh pr create --draft`). The author marks it ready for review manually.
+
+## Title
+
+1. Read types, scopes, and formatting rules from the project's `CONTRIBUTING.md` (usually a `Conventions` section). If the project defines none, fall back to Conventional Commits types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`.
+2. The PR title should mirror the header of the main commit in the PR.
+3. Format the title as `<type>(<scope>): <subject>`.
+4. Keep the total length ≤ 72 characters.
+5. Nested scopes are allowed and encouraged where the project supports them.
+6. Subject: imperative present tense, no capitalized first letter, no trailing dot.
+
+## Description
+
+Use the following structure. Every section is **mandatory** — omit a section only when it genuinely does not apply (e.g. single-line typo fix may skip *Review focus / risks*).
+
+```
+## Summary
+
+<1-3 sentence high-level overview of what the PR does and why it exists.>
+
+## Key changes
+
+- <concrete change 1>
+- <concrete change 2>
+- …
+
+## Why
+
+<Motivation: what problem this solves, what maintenance/UX/perf gain it brings.>
+
+## Review focus / risks
+
+- <area or file that deserves careful review>
+- <potential risk or side-effect>
+```
+
+### Rules
+
+- Language: match the project's primary language (English by default).
+- Be specific: name files, modules, functions — not "updated some code".
+- *Key changes*: group related items; use sub-bullets for detail when helpful.
+- *Why*: explain the reason, not what changed (that's *Key changes*).
+- *Review focus / risks*: guide the reviewer — call out non-obvious consequences, large generated diffs, breaking changes.
+- No AI-slop filler ("This PR improves the codebase…"). Every sentence must carry information.
+
+## Output
+
+When generating only the title (e.g. for `gh pr edit --title`), output ONLY the title, with no additional text, quotes, or formatting.

--- a/.agents/skills/rigorous-review/SKILL.md
+++ b/.agents/skills/rigorous-review/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: rigorous-review
+description: Evidence-based code review of a PR, branch, or diff — technical, product, and risk perspectives in one pass, with mandatory test-quality (mutation) checks and an honest "not verified" account. Use when asked to review a PR, branch, or code changes.
+---
+
+# Rigorous Code Review
+
+Evidence-based and blunt. Every finding references a specific `file:line`, function, or component. NEVER sugarcoat, NEVER pad with praise, NEVER report a concern that is not grounded in the diff or the codebase. Style preferences are not defects — but a violation of the project's own conventions (its `AGENTS.md` / `CLAUDE.md` / `CONTRIBUTING.md` / style guide) is a convention finding, not a preference.
+
+## Before reviewing
+
+1. Ask the user for numbered acceptance criteria (DoD). If there are none, derive them from the PR description or the linked issue, mark them `(inferred)`, and proceed — do not stall, and do not invent criteria silently.
+2. Resolve the base first: `git fetch`, then diff against the branch this change actually targets — not blindly `main`/`master` (many projects maintain release branches; a backport's real base is the release branch, not the trunk). State the resolved base in the report. For uncommitted work, review `git diff` / `git diff --cached` instead.
+3. Read every changed file. Then trace callers of changed exported symbols whose signature or behavior changed, and of anything crossing a persistence or API boundary — via LSP call hierarchy and references where available, not grep alone.
+4. For 10+ changed files, split the reading by area across subagents if your harness has them, and synthesize the findings yourself.
+5. Check the project's own docs (`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, a style guide, a project-specific review skill) for conventions, build/test commands, and known landmines before forming an opinion — a project's own accumulated gotchas beat generic defaults every time.
+6. If the worktree holds the branch and it's buildable, actually build and run the relevant tests — a review that never compiled the change is an opinion, not a review. NEVER run an auto-formatter as part of this: it would rewrite the diff under review.
+
+## Technical perspective
+
+Code structure and correctness only — user impact belongs to the product perspective.
+
+- Conventions: the project's own style guide/`AGENTS.md`/`CLAUDE.md` is the standard, not your default taste. Flag deviations from the project's stated preferences in either direction (e.g., if the project explicitly prefers duplication over abstraction, don't file duplication as a defect on its own, but do flag needless abstraction).
+- Correctness: error handling and discarded errors, resource lifecycle and cancellation, concurrency ownership, nil/uninitialized state, boundary conditions.
+- Security: least privilege, input validation, secret handling.
+- Observability: when an operation fails, is the cause visible to whoever operates this system?
+- Testability: can the change be exercised without external dependencies (network, cluster, hardware)?
+- Consistency with the patterns already established elsewhere in this codebase.
+
+Cover the ones the diff actually touches; stay silent about the rest.
+
+## Tests as evidence (mandatory)
+
+Passing tests, high coverage, and the author's confidence are not evidence of correctness, whoever wrote the diff. For every load-bearing test touched by or covering the diff, run the `test-the-tests` skill's mutation loop against it. This is not optional — skipping it because the tests "look thorough" is exactly the failure mode it exists to catch.
+
+If the diff's author is an agent, or the diff touches tests or verification infrastructure, also load the `agent-code-review` skill — it adds check-gaming detection (weakened assertions, quietly skipped tests, mocked-out critical behavior, and more) and explains this review's limits when you are the diff's own author. Load it there rather than re-deriving the same checklist here, so the two stay in sync.
+
+## Product perspective
+
+What the change does for the user — not how the code is written.
+
+- User impact: UX, error messages, naming, defaults, output formatting, breaking changes.
+- Completeness: edge cases (empty states, conflicting options, boundary sizes).
+- Consistency: matches existing conventions elsewhere in the product.
+- Surface area: a public API/CLI/config change needs a migration or deprecation path; a change to machine-readable output (exit codes, structured output consumed by other tools) is a breaking change even if humans don't notice.
+- Documentation: is it out of date after this change, and does the project generate it (don't hand-edit generated docs — fix the generator or source).
+
+## Risks
+
+Derive risks from the technical and product findings plus the diff — including compound ones, where a technical flaw produces a product gap or an operational hazard. Likelihood is Likely/Possible/Unlikely, severity is Critical/High/Medium/Low; be realistic, do not inflate. Every risk needs a concrete location.
+
+Classify each risk as Technical, Security, UX/Product, or Operational, and report risks only when they exist — an empty matrix is noise.
+
+## Output
+
+Print the report. Do not write it into the repository unless the user asks for a file.
+
+```markdown
+# Code Review Report
+
+**Base:** `<resolved base branch>`
+**Diff:** [X files, +Y/-Z lines]
+
+## Verdict
+
+- Technical: [up to 3 sentences, or `no findings`]
+- Product: [up to 3 sentences, or `no findings`]
+- Risk: [up to 3 sentences, or `no findings`]
+
+## DoD Criteria
+
+| Criteria | Inferred? | Met? | Evidence |
+| :--- | :--- | :--- | :--- |
+| [criterion] | yes/no | ✅/⚠️/❌ | file:line |
+
+## Issues
+
+- **Critical** — blocking, with file:line
+- **Major** — significant concern
+- **Minor** — suggestion
+
+## Risks
+
+Sorted by severity, then by likelihood.
+
+| № | Risk | Type | Likelihood | Severity | Location | Circumstances | Consequences | Recommendation |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+
+## Not verified
+
+- What was not built, run, or reachable — and why (platform limitation, missing infra, out-of-scope environment).
+```
+
+- **Recommendation** — the concrete action, with file:line references.
+
+## Language
+
+Headers in English, everything else in the user's language.

--- a/.agents/skills/test-the-tests/SKILL.md
+++ b/.agents/skills/test-the-tests/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: test-the-tests
+description: >
+  Verify that a test actually falsifies the behavior it claims to cover, via real mutation
+  (not just reading the assertions). Use right after writing or changing tests — before
+  considering that work done — when auditing an existing suite's real coverage, as a step
+  inside a broader code review, or when invoked as /test-the-tests. Passing and high
+  coverage are not evidence; a test that survives a plausible fault is weak regardless of
+  whether it currently passes.
+---
+
+# Test the Tests
+
+A test's value is what it would catch, not what it currently asserts. Don't stop at "does
+this read as correct" — ask:
+
+> What fault would this test fail to catch?
+
+This applies to your own tests as much as anyone else's. Writing a test and watching it
+pass proves the test *runs*; it does not prove the test *discriminates* correct from
+incorrect behavior. Treat "I just wrote this test" as no more trustworthy than "someone
+else wrote this test."
+
+## The mutation loop
+
+For each test that carries real weight (guards a fix, a regression, an invariant — not a
+trivial getter):
+
+1. Pick the smallest plausible fault: invert a condition, change `<` to `<=`, remove a
+   validation, suppress an error, skip a side effect, hardcode/return a constant, revert to
+   the prior (buggy) implementation.
+2. Apply it directly to the implementation.
+3. Run the test. It must fail, with a message that points at the actual broken behavior —
+   not a crash unrelated to the property under test.
+4. Revert the fault immediately, confirm the tree is clean (`git diff`/`git status`), and
+   confirm the suite passes again.
+
+If running the mutation isn't practical (expensive integration setup, no easy revert),
+name the smallest mutation that should be tried instead of skipping the exercise — that
+name is itself the finding when no one can say what it is.
+
+Do not leave mutated code in the repository, even temporarily between steps — always
+restore from a real diff/backup and re-verify a clean tree before moving on.
+
+## Common ways a test looks strong but isn't
+
+- **The assertion is satisfied by more than the fix.** A chain assertion like
+  `index(a) < index(b) < index(c)` can hold under both the correct implementation and the
+  bug it's meant to catch, if the specific scenario doesn't force them to disagree. Reshape
+  the scenario (add a case whose correct answer differs from what the bug would produce)
+  rather than trusting that "the numbers came out right" once.
+- **It re-asserts a second recording of the same event instead of the event itself.**
+  Comparing two independently-recorded orderings (e.g. two separate mutex-protected
+  append lists) is often racier and weaker than asserting a property that's true by
+  construction (a monotonic counter, a guaranteed dependency order).
+- **It only exercises the unit in isolation**, never the real wiring that a regression
+  would actually break (e.g. calling a scheduler's internal methods directly instead of
+  going through the real caller that's supposed to invoke them). Prefer driving the actual
+  entry point end-to-end when the risk is in the wiring, not just the unit.
+- **It asserts implementation trivia** (a mock was called N times, an internal helper ran)
+  instead of externally observable behavior a user or caller would notice.
+- **Coverage number, not falsifiability.** A line being executed says nothing about whether
+  a wrong value on that line would be caught.
+
+## Output
+
+For each test you verified this way, state: the fault you tried, whether it failed as
+expected, and if not, the smallest concrete change to the test that would make it
+discriminate. For tests you didn't (couldn't) mutate, name the smallest fault that should
+be tried next, rather than asserting confidence without it.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,13 @@ All rules in this document are requirements — not suggestions. ALWAYS follow t
 
 trdl (true delivery) is an Open Source solution providing a secure channel for delivering updates from the Git repository to the end user. It uses [Vault](https://www.vaultproject.io/) to verify operations and [TUF](https://theupdateframework.io/) for secure software distribution. trdl is a multi-module Go project with three components: trdl-server (a Vault plugin), trdl-client (a CLI tool), and trdl-vault (a release CLI tool).
 
+`.agents/skills` holds mandatory agent skills: branch and commit conventions, PR format, code review, test verification. `.claude/skills` is a symlink to it, `CLAUDE.md` is a symlink to this file.
+
 ## Highest-priority rule (MANDATORY)
 
 - NEVER add comments unless they document a non-obvious public API or explain genuinely non-obvious logic. NEVER add comments that restate what the code does, repeat the field/function name, describe obvious error handling, or act as section separators. When in doubt, don't comment.
 - ALWAYS use `task` commands for build/test/lint/format — NEVER raw `go build`, `go test`, `go vet`, `go fmt`, or `golangci-lint` directly.
+- ALWAYS read the matching skill in `.agents/skills/` BEFORE the action it governs and follow it verbatim: `git-conventions/SKILL.md` before naming a branch or writing a commit message, `pull-request/SKILL.md` before creating or updating a PR (title, description, draft by default), `rigorous-review/SKILL.md` before reviewing code, `test-the-tests/SKILL.md` before considering a new or changed test done, `agent-code-review/SKILL.md` in addition to `rigorous-review/SKILL.md` when the diff's author is an agent or the diff touches tests. These files are the source of truth and are NOT duplicated here.
 - ALWAYS verify, don't assume — check the actual state before making changes.
 - ALWAYS start with the simplest possible solution. If it works, stop. Add complexity only when justified by a concrete, current requirement — NEVER for hypothetical future needs.
 - NEVER leave TODOs, stubs, or partial implementations.
@@ -57,6 +60,12 @@ Follow [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comme
 - NEVER discard errors with `_`. Indent error flow, not happy path.
 - NEVER use dot imports.
 - NEVER use named returns or naked returns.
+
+## Code navigation (MANDATORY)
+
+- ALWAYS use LSP (`goToDefinition`, `findReferences`, `documentSymbol`, `hover`, `goToImplementation`, call hierarchy) to find definitions, usages, implementations, and callers. `grep` matches strings blindly: it hits comments and unrelated identifiers, and misses interface dispatch and aliased imports.
+- Use `grep` ONLY for literal text — config keys, error message strings, annotation names.
+- If your harness has a semantic code-search tool, prefer it over `grep` for intent-based questions ("how does X work"). If it does not, read the code: NEVER substitute keyword grepping for understanding.
 
 ## Commands (MANDATORY)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

trdl has `AGENTS.md` but no skills directory, so the conventions werf keeps in `.agents/skills` — branch and commit format, PR format, code review, test verification — were unavailable to agents working in this repo. This brings that harness over, mirroring the werf/werf layout.

## Key changes

- `.agents/skills/` — five shared skills: `git-conventions`, `pull-request`, `rigorous-review`, `agent-code-review`, `test-the-tests`. They are project-agnostic and read types and scopes from `CONTRIBUTING.md#conventions`, so trdl's own scope list stays the source of truth.
- `.claude/skills` → `.agents/skills` and `CLAUDE.md` → `AGENTS.md`, both relative symlinks, so Claude Code finds the harness without a second copy of anything.
- `AGENTS.md` — a mandatory rule mapping each skill to the action it governs (`git-conventions` before naming a branch or writing a commit, `pull-request` before opening a PR, `rigorous-review` before reviewing, `test-the-tests` before calling a test done, `agent-code-review` on top of review for agent-authored diffs), plus a `Code navigation` section: LSP for definitions/references/implementations, `grep` only for literal text.

## Why

The rules already existed and were already applied by hand in this repo; keeping them in the repo makes them enforceable instead of remembered, and identical to what werf/werf uses so contributors and agents do not have to learn two dialects. Naming the skills in `AGENTS.md` means an agent has to read the convention before the action, rather than reconstructing it from recent history.

## Review focus / risks

- Docs and config only — no Go code, no build or test impact.
- Skills are real copies rather than symlinks into a developer's home directory, which would be broken in every other clone. The accepted trade-off: these copies can drift from their upstream versions and have to be re-synced by hand.
- `OPENCODE.md` still documents tooling that is not part of the current harness (CodeAlive MCP, `ast_grep_*`, `explore`-agent workarounds) and now partially overlaps the new `Code navigation` section. Left untouched deliberately — separate cleanup.