### PR TITLE
fix(ci): grant actions: read to website converge workflows

### DIFF
--- a/.github/workflows/website_converge_eu.yml
+++ b/.github/workflows/website_converge_eu.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   converge:
     permissions:
+      actions: read
       contents: read
       id-token: write
       packages: write

--- a/.github/workflows/website_converge_ru.yml
+++ b/.github/workflows/website_converge_ru.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   converge:
     permissions:
+      actions: read
       contents: read
       id-token: write
       packages: write


### PR DESCRIPTION
## Summary

Website converge runs (`Converge website EU` / `Converge website RU`) have failed with `startup_failure` on every push since 2026-07-01, so trdl.dev still serves the build from 2026-06-02. Granting `actions: read` to the calling jobs unblocks the deploy.

## Key changes

- `.github/workflows/website_converge_eu.yml`, `.github/workflows/website_converge_ru.yml`: add `actions: read` to the `converge` job `permissions` block.

## Why

`_website_converge.yml` calls `werf/common-ci/.github/workflows/notification.yml@main`, which since werf/common-ci@77b2a349 (2026-06-15) declares workflow-level `permissions: actions: read`. A nested reusable workflow cannot escalate beyond the permissions its caller granted, and these two workflows are the only ones in trdl that pin job permissions (`contents: read`, `id-token: write`, `packages: write`) — so the whole run is rejected before any job starts. Consequence: docs merged after 2026-06-02 are not published, e.g. `https://trdl.dev/reference/vault_plugin/configure/delivery_kit_elf_signing.html` returns 404 although the page exists in `main` since #389.

## Review focus / risks

- `actions: read` is read-only metadata access needed by the notification job to inspect run jobs; the converge job itself does not use it.
- Merging this triggers both converge workflows automatically (their `on.push.paths` include the workflow files themselves), which republishes the site — verify the runs actually reach the `Converge` step this time.