### PR TITLE
fix(server): unhang the release on a long log line and a passwordless certificate

### DIFF
--- a/server/pkg/docker/builder.go
+++ b/server/pkg/docker/builder.go
@@ -197,6 +197,8 @@ func (b *Builder) Remove(ctx context.Context) error {
 	return nil
 }
 
+const maxLogLineSize = 1024 * 1024
+
 // The returned wait function closes the writer and returns once every buffered
 // line has reached the logger, so the tail of a build log is not lost when the
 // build finishes.
@@ -205,8 +207,13 @@ func logWriter(logger Logger) (*io.PipeWriter, func()) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
+		// The build writes into this pipe, so the moment line parsing stops the
+		// build itself blocks on the next write. Whatever happens above, keep
+		// draining until the writer is closed.
+		defer func() { _, _ = io.Copy(io.Discard, pr) }()
 
 		scanner := bufio.NewScanner(pr)
+		scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxLogLineSize)
 		for scanner.Scan() {
 			line := scanner.Text()
 			logger.Info(line)
@@ -216,7 +223,7 @@ func logWriter(logger Logger) (*io.PipeWriter, func()) {
 			}
 		}
 		if err := scanner.Err(); err != nil {
-			logger.Error("error reading stderr", "err", err)
+			logger.Error("unable to read build output, the rest of it is not logged", "err", err)
 		}
 	}()
 

--- a/server/pkg/docker/buildkit.go
+++ b/server/pkg/docker/buildkit.go
@@ -67,9 +67,7 @@ func buildkitSecretsData(buildSecrets []secrets.Secret, macSigningCredentials *m
 	if macSigningCredentials != nil {
 		identityName := mac_signing.MacSigningCertificateName
 		data[identityName+"_cert"] = []byte(macSigningCredentials.Certificate)
-		if macSigningCredentials.Password != "" {
-			data[identityName+"_password"] = []byte(macSigningCredentials.Password)
-		}
+		data[identityName+"_password"] = []byte(macSigningCredentials.Password)
 		data[identityName+"_notary_key_id"] = []byte(macSigningCredentials.NotaryKeyID)
 		data[identityName+"_notary_key"] = []byte(macSigningCredentials.NotaryKey)
 		data[identityName+"_notary_issuer"] = []byte(macSigningCredentials.NotaryIssuer)

--- a/server/pkg/docker/buildkit_ai_test.go
+++ b/server/pkg/docker/buildkit_ai_test.go
@@ -3,8 +3,10 @@
 package docker
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/werf/logboek"
+	"github.com/werf/trdl/server/pkg/mac_signing"
 )
 
 func TestAI_BuildkitSessionAttachables_ServeContextSecretsAndRegistryAuth(t *testing.T) {
@@ -88,6 +91,53 @@ func TestAI_LogWriter_WaitReturnsOnlyAfterEveryLineIsLogged(t *testing.T) {
 	logger.mu.Lock()
 	defer logger.mu.Unlock()
 	assert.Equal(t, []string{"first", "second", "third"}, logger.lines)
+}
+
+func TestAI_LogWriter_OversizedLineDoesNotBlockTheBuild(t *testing.T) {
+	logger := &recordingLogger{}
+	writer, waitForLogs := logWriter(logger)
+
+	writeErr := make(chan error, 1)
+	go func() {
+		if _, err := writer.Write(append(bytes.Repeat([]byte("x"), maxLogLineSize+1), '\n')); err != nil {
+			writeErr <- err
+			return
+		}
+		_, err := io.WriteString(writer, "line after the oversized one\n")
+		writeErr <- err
+	}()
+
+	select {
+	case err := <-writeErr:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the build is blocked writing its output after an oversized log line")
+	}
+	waitForLogs()
+
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	assert.Contains(t, strings.Join(logger.lines, "\n"), "unable to read build output",
+		"dropping the rest of the build output has to be reported")
+}
+
+func TestAI_MacSigningSecrets_PasswordlessCertificateIsStillServed(t *testing.T) {
+	credentials := &mac_signing.Credentials{
+		Certificate:  "cert-data",
+		NotaryKeyID:  "key-id",
+		NotaryKey:    "key-data",
+		NotaryIssuer: "issuer-id",
+	}
+	passwordId := mac_signing.MacSigningCertificateName + "_password"
+
+	// The generated Dockerfile mounts the password unconditionally and reads it
+	// under `set -e`, so both build paths have to serve it even when it is empty.
+	data := buildkitSecretsData(nil, credentials)
+	if assert.Contains(t, data, passwordId) {
+		assert.Empty(t, data[passwordId])
+	}
+
+	assert.Contains(t, GetMacSigningCommandMounts(credentials), "id="+passwordId)
 }
 
 func TestAI_Build_UnblocksContextProducerWhenBuildFails(t *testing.T) {

--- a/server/pkg/docker/buildkit_test.go
+++ b/server/pkg/docker/buildkit_test.go
@@ -93,16 +93,7 @@ func TestBuildkitSecretsData(t *testing.T) {
 	}, data)
 }
 
-func TestBuildkitSecretsData_NoPasswordNoCredentials(t *testing.T) {
+func TestBuildkitSecretsData_NoCredentials(t *testing.T) {
 	data := buildkitSecretsData([]secrets.Secret{{Id: "MY_TOKEN", Data: []byte("token-value")}}, nil)
 	assert.Equal(t, map[string][]byte{"MY_TOKEN": []byte("token-value")}, data)
-
-	data = buildkitSecretsData(nil, &mac_signing.Credentials{
-		Certificate:  "cert-data",
-		NotaryKeyID:  "key-id",
-		NotaryKey:    "key-data",
-		NotaryIssuer: "issuer-id",
-	})
-	identityName := mac_signing.MacSigningCertificateName
-	assert.NotContains(t, data, identityName+"_password")
 }

--- a/server/pkg/docker/mac_signing.go
+++ b/server/pkg/docker/mac_signing.go
@@ -12,9 +12,9 @@ func GetMacSigningCommandMounts(creds *mac_signing.Credentials) []string {
 	if creds != nil {
 		identityName := mac_signing.MacSigningCertificateName
 		args = append(args, "--secret", fmt.Sprintf("id=%s_cert", identityName))
-		if creds.Password != "" {
-			args = append(args, "--secret", fmt.Sprintf("id=%s_password", identityName))
-		}
+		// The signer stage reads the password unconditionally, so a passwordless
+		// certificate has to be served as an empty secret rather than as none.
+		args = append(args, "--secret", fmt.Sprintf("id=%s_password", identityName))
 		args = append(args, "--secret", fmt.Sprintf("id=%s_notary_key_id", identityName))
 		args = append(args, "--secret", fmt.Sprintf("id=%s_notary_key", identityName))
 		args = append(args, "--secret", fmt.Sprintf("id=%s_notary_issuer", identityName))
@@ -32,10 +32,8 @@ func SetMacSigningTempEnvVars(creds *mac_signing.Credentials) error {
 		return fmt.Errorf("unable to set certificate env var: %w", err)
 	}
 
-	if creds.Password != "" {
-		if err := os.Setenv(identityName+"_password", creds.Password); err != nil {
-			return fmt.Errorf("unable to set password env var: %w", err)
-		}
+	if err := os.Setenv(identityName+"_password", creds.Password); err != nil {
+		return fmt.Errorf("unable to set password env var: %w", err)
 	}
 
 	if err := os.Setenv(identityName+"_notary_key_id", creds.NotaryKeyID); err != nil {


### PR DESCRIPTION
## Summary

Two release-build defects that predate #409 and affect both build paths: an oversized build log line hangs the release task, and a passwordless mac signing certificate fails the signer stage.

## Why

Both turn an ordinary situation into a broken release, and neither reports a cause the operator can act on.

`bufio.Scanner` stops at `bufio.ErrTooLong` on a line above 64 KB, after which the goroutine reading the pipe returns. The build keeps writing into that pipe, so the next write blocks forever — `cmd.Run` on the docker CLI path, the progress display on the BuildKit client path — and the release task hangs with no error, until the plugin process is restarted.

The generated service Dockerfile mounts `certificate_password` unconditionally and reads it with `cat` under `set -e -o pipefail`, while both build paths served that secret only when the stored password was non-empty. `--mount=type=secret` defaults to `required=false`, so BuildKit mounts nothing and the `cat` takes the whole `RUN` down. A passwordless p12 is legitimate.

## Key changes

- `server/pkg/docker/builder.go` — `logWriter` raises the line limit to 1 MiB and drains the pipe to `io.Discard` in a deferred call, so parsing that stops for any reason can no longer block the writer. An oversized line now costs the rest of the build log, reported through the logger, instead of the release.
- `server/pkg/docker/mac_signing.go`, `server/pkg/docker/buildkit.go` — the password secret is always served, with an empty value when there is none, so quill receives an empty `QUILL_SIGN_PASSWORD`. Both paths mount the same ids and are changed together.
- `server/pkg/docker/buildkit_test.go` — `TestBuildkitSecretsData_NoPasswordNoCredentials` asserted the defect (`NotContains` the password id); the passwordless half is replaced by the new test below, and what remains covers the no-credentials case.

## Verification

- Mutations run, each reverted after the run, each killing exactly the test that covers it:
  - removing the drain from `logWriter` → `TestAI_LogWriter_OversizedLineDoesNotBlockTheBuild` fails after its 30s timeout, reporting the blocked writer;
  - restoring `if Password != ""` in `buildkitSecretsData` → `TestAI_MacSigningSecrets_PasswordlessCertificateIsStillServed` fails;
  - restoring the same condition in `GetMacSigningCommandMounts` → the same test fails, so both halves of it discriminate.
- Not run: a release with a passwordless certificate through the mac-signing e2e suite. Its quill stub validates the five `QUILL_*` variables, so accepting an empty password there is a change to the fixture rather than a run of the existing one.

## Review focus / risks

- The 1 MiB limit is a judgement call: below it a line is buffered whole, above it the remaining log is dropped. The hang is gone either way, and the drop is logged.
- An empty `QUILL_SIGN_PASSWORD` reaches quill for a passwordless certificate. This is the intended reading of "no password", but it is a behaviour change for anyone who stored an empty password expecting the release to fail.

## After merge

- [ ] Close #410 and #411 (linked by `Fixes` in the commits, so a squash merge closes them automatically — verify it did).
