### PR TITLE
docs: state that the buildx settings are ignored in BuildKit mode

### DIFF
--- a/docs/pages_en/QUICKSTART.md
+++ b/docs/pages_en/QUICKSTART.md
@@ -70,7 +70,7 @@ or, as a fallback for all projects, with the `TRDL_BUILDKITD_ADDRESS` environmen
 * `unix://` and `tcp://` — direct gRPC connection to buildkitd, no external binaries required;
 * `docker-container://` and `kube-pod://` — connection through `docker exec`/`kubectl exec`, requiring the corresponding CLI.
 
-When `buildkitd_address` is not set, builds go through `docker buildx` exactly as described above. Deploying `buildkitd` itself is out of trdl's scope: on Kubernetes it is typically a Deployment or StatefulSet in a dedicated namespace whose PodSecurity labels are managed by the cluster owner, since BuildKit requires a relaxed seccomp/AppArmor profile even in rootless mode.
+With an address set, no buildx builder is created, so the `TRDL_BUILDX_DRIVER` and `TRDL_BUILDX_DRIVER_OPTS_*` settings above have no effect on the build. When `buildkitd_address` is not set, builds go through `docker buildx` exactly as described above. Deploying `buildkitd` itself is out of trdl's scope: on Kubernetes it is typically a Deployment or StatefulSet in a dedicated namespace whose PodSecurity labels are managed by the cluster owner, since BuildKit requires a relaxed seccomp/AppArmor profile even in rootless mode.
 
 Securing the connection and isolating the daemon is the administrator's responsibility. The plugin sends the entire build context and every build secret over this connection — the project build secrets and, when mac signing is configured, the signing certificate, its password and the notary key. What that requires:
 

--- a/docs/pages_ru/QUICKSTART.md
+++ b/docs/pages_ru/QUICKSTART.md
@@ -69,7 +69,7 @@ vault write trdl-test-project/configure ... buildkitd_address=tcp://buildkitd.tr
 * `unix://` и `tcp://` — прямое gRPC-соединение с buildkitd, внешние бинарники не нужны;
 * `docker-container://` и `kube-pod://` — соединение через `docker exec`/`kubectl exec`, требуется соответствующий CLI.
 
-Если `buildkitd_address` не задан, сборка идёт через `docker buildx`, как описано выше. Развёртывание самого `buildkitd` находится вне зоны ответственности trdl: в Kubernetes это обычно Deployment или StatefulSet в отдельном namespace, метки PodSecurity которого задаёт владелец кластера, поскольку BuildKit требует ослабленный профиль seccomp/AppArmor даже в rootless-режиме.
+Если адрес задан, buildx-сборщик не создаётся, поэтому настройки `TRDL_BUILDX_DRIVER` и `TRDL_BUILDX_DRIVER_OPTS_*` выше на сборку не влияют. Если `buildkitd_address` не задан, сборка идёт через `docker buildx`, как описано выше. Развёртывание самого `buildkitd` находится вне зоны ответственности trdl: в Kubernetes это обычно Deployment или StatefulSet в отдельном namespace, метки PodSecurity которого задаёт владелец кластера, поскольку BuildKit требует ослабленный профиль seccomp/AppArmor даже в rootless-режиме.
 
 Защита канала и изоляция демона — ответственность администратора. Через это соединение плагин передаёт весь контекст сборки и все секреты сборки: секреты проекта, а если настроена подпись для macOS — сертификат подписи, его пароль и notary-ключ. Что из этого следует:
 


### PR DESCRIPTION
The buildkitd section in QUICKSTART (en/ru) says no builder is provisioned per build, but not what that means for the `TRDL_BUILDX_DRIVER` and `TRDL_BUILDX_DRIVER_OPTS_*` settings documented right above it: with `buildkitd_address` set they have no effect at all. One sentence in each locale, so a driver that is configured and then unused does not read as a bug.

Note for #412: once the driver is settable through `configure` too, this sentence has to name those fields as well.