### PR TITLE
chore(docs): regenerate the stale trdl use partial

### DIFF
--- a/docs/_includes/reference/cli/trdl_use.md
+++ b/docs/_includes/reference/cli/trdl_use.md
@@ -12,8 +12,7 @@ trdl use REPO GROUP [CHANNEL] | REPO VERSION [options]
   # Source script in a shell
   $ . $(trdl use repo_name 1.2 ea)
 
-  # Pin an explicit version instead of a group/channel
-  # (an exact version must be prefixed with "v", otherwise it is treated as a group)
+  # Pin an exact version (prefix it with "v"; a plain number like "1.2" is a GROUP)
   $ . $(trdl use repo_name v1.2.3)
 
   # Pin a semver constraint (resolves to the greatest matching release)


### PR DESCRIPTION
`docs/_includes/reference/cli/trdl_use.md` still described the `trdl use` help text from before #391, so `task docs:gen` produced a diff on a clean checkout of `main` and every PR touching the generator picked up this unrelated change. Regenerated on its own, no hand edits.

Noticed while working on #409, where the same diff appeared and was reverted to keep that PR scoped.