### PR TITLE
chore(dev): let the test tasks take paths and record two harness landmines

### DIFF
--- a/.agents/skills/test-the-tests/SKILL.md
+++ b/.agents/skills/test-the-tests/SKILL.md
@@ -38,6 +38,13 @@ seen fail.
 
 ## Common ways a test looks strong but isn't
 
+- **A real daemon, cluster or network is one mutation away.** A test that reaches the code
+  under test through a validation error — "the driver is rejected, so `docker buildx create`
+  is never called" — has its only barrier inside the thing being mutated. Invert that
+  validation and the test provisions real infrastructure, leaves it behind, and hangs instead
+  of failing when nothing drains what the code writes. Neutralize the escape before relying
+  on it (an empty `PATH`, an unroutable address) and drain every pipe the code writes to, so
+  the fault fails the test rather than the machine running it.
 - **The assertion holds under the bug too.** A chain assertion like
   `index(a) < index(b) < index(c)` can pass under both the fix and the regression it's
   meant to catch if the scenario doesn't force them to disagree. Reshape the scenario (add

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Follow [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comme
 
 ## Commands (MANDATORY)
 
-ALWAYS use these `task` commands. NEVER use raw `go build`, `go test`, `go fmt`, `go vet`, or `golangci-lint` directly. trdl is a multi-module project — most commands are namespaced by module.
+ALWAYS use these `task` commands. NEVER use raw `go build`, `go test`, `go fmt`, `go vet`, or `golangci-lint` directly. trdl is a multi-module project — most commands are namespaced by module, and those namespaces exist only in the root Taskfile: ALWAYS run `task` from the repository root, never from inside `server/`, `client/`, `e2e/` or `release/`.
 
 ### Building
 - NEVER `go build` → ALWAYS use the appropriate build task:
@@ -96,6 +96,7 @@ ALWAYS use these `task` commands. NEVER use raw `go build`, `go test`, `go fmt`,
 
 ## Testing (MANDATORY)
 
+- `logboek.Context(ctx)` returns the default logger ONLY for exactly `context.Background()`; any derived context without a bound logger panics with `context is not bound with logboek logger`. In a test that reaches code logging through logboek, pass `context.Background()` unchanged or wrap it: `logboek.NewContext(ctx, logboek.DefaultLogger())`.
 - Server tests use Ginkgo/Gomega. `testify` (`assert`, `require`) is also available in the `server/` module.
 - E2E tests use Ginkgo/Gomega exclusively.
 - When writing tests as an AI agent → ALWAYS name the file `*_ai_test.go`, add `//go:build ai_tests` build tag, prefix test functions with `TestAI_`.

--- a/e2e/Taskfile.yaml
+++ b/e2e/Taskfile.yaml
@@ -37,13 +37,14 @@ tasks:
       CGO_ENABLED: "0"
 
   test:e2e:
-    desc: "Run client e2e test."
+    desc: 'Run client e2e test. Important vars: "paths", "focusFilter", "labelFilter".'
     # On linux/amd64 the elf_signing suite links the delivery-kit-sdk CGO ELF
     # signer via the server import, so it needs the C libs from
     # server:deps:install:c. On other platforms that suite is skipped.
-    cmd: ginkgo --vv --keep-going --cover --covermode=atomic --coverpkg=github.com/werf/trdl/client/...,github.com/werf/trdl/server/... --output-dir={{.outputDir}} ./...
+    cmd: ginkgo --vv --keep-going --cover --covermode=atomic --coverpkg=github.com/werf/trdl/client/...,github.com/werf/trdl/server/... --output-dir={{.outputDir}} {{if .focusFilter}}--focus="{{.focusFilter}}" {{end}}{{if .labelFilter}}--label-filter="{{.labelFilter}}" {{end}}{{.paths}}
     vars:
       outputDir: '{{.outputDir | default "../tests_coverage/e2e" }}'
+      paths: '{{.paths | default "./..."}}'
 
   test:e2e:elf-signing:
     desc: "Run ELF signing e2e test (linux/amd64 with CGO; requires server:deps:install:c)."

--- a/server/Taskfile.yaml
+++ b/server/Taskfile.yaml
@@ -323,14 +323,17 @@ tasks:
           goTags: "test_coverage"
 
   test:unit:
-    desc: "Run server unit tests."
-    cmd: ginkgo --vet=off --race --keep-going --cover --coverpkg=./... --output-dir={{.outputDir}} ./...
+    desc: 'Run server unit tests. Important vars: "paths".'
+    cmd: ginkgo --vet=off --race --keep-going --cover --coverpkg=./... --output-dir={{.outputDir}} {{.paths}}
     vars:
       outputDir: '{{.outputDir | default "../tests_coverage/unit"}}'
+      paths: '{{.paths | default "./..."}}'
 
   test:ai:
-    desc: "Run server tests written by AI agents (ai_tests build tag). Set TRDL_SMOKE_BUILDKITD_ADDRESS to include the buildkitd smoke test."
-    cmd: ginkgo --vet=off --race --keep-going --tags=ai_tests ./...
+    desc: 'Run server tests written by AI agents (ai_tests build tag). Set TRDL_SMOKE_BUILDKITD_ADDRESS to include the buildkitd smoke test. Important vars: "paths".'
+    cmd: ginkgo --vet=off --race --keep-going --tags=ai_tests {{.paths}}
+    vars:
+      paths: '{{.paths | default "./..."}}'
 
   verify:dist:binaries:
     desc: "Verify that the distributable binaries are built and have correct platform/arch."


### PR DESCRIPTION
## Summary

`task server:test:unit paths="./pkg/docker/..."` now runs one suite in 4s instead of the whole module in 1m50s. The var was documented in AGENTS.md but the task hardcoded `./...`, so every scoped attempt silently ran everything.

## What

- `server:test:unit`, `server:test:ai` and `e2e:test:e2e` pass `paths` through to ginkgo, defaulting to `./...`; `e2e:test:e2e` also passes `focusFilter` and `labelFilter`, which AGENTS.md documented and the task never used.
- AGENTS.md states that namespaced targets exist only in the root Taskfile, so `task` runs from the repository root — `task server:test:unit` inside `server/` fails with "does not exist".
- AGENTS.md states that `logboek.Context()` returns the default logger only for exactly `context.Background()`, and panics on any derived context with no logger bound.
- `.agents/skills/test-the-tests` gains one mutation hazard: a test whose only barrier before a real daemon is a validation error inside the code being mutated provisions real infrastructure once that validation is inverted, and hangs instead of failing when nothing drains what the code writes.
- Nothing changes for an unscoped run: the default keeps the previous argument list.

## Why

All four items are this session's cost, not hypotheticals. The `paths` gap made every targeted check a full-module wait. The two AGENTS.md lines each burned a step — one failed invocation and one test that panicked inside logboek. The skill bullet is the mechanism behind an incident an independent reviewer hit while mutating #419: the mutated validation was the only thing keeping a unit test away from the machine's Docker, so the run created two BuildKit Deployments in a live cluster and deadlocked with no `FAIL` line at all.